### PR TITLE
pos1_typo

### DIFF
--- a/ctmc_lectures/poisson.md
+++ b/ctmc_lectures/poisson.md
@@ -330,7 +330,7 @@ $$
 
 In particular, increments are stationary.
 
-The approximation also illustrates indepenence of increments, since, in the
+The approximation also illustrates independence of increments, since, in the
 approximation, increments depend on separate subsets of $(V_i)$.
 
 


### PR DESCRIPTION
Hi @jstac , this PR corrected a typo
- ``indepenence`` -> ``independence``

Please find [here](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/poisson.md#uniqueness) (the sentence above subsection **Uniqueness**).