### PR TITLE
pos2_redundant

### DIFF
--- a/ctmc_lectures/poisson.md
+++ b/ctmc_lectures/poisson.md
@@ -304,7 +304,7 @@ between $s$ and $s+t$, so that
 
 $$
     \hat N_{s+t} - \hat N_s
-    = \sum_i V_i \mathbb 1\{ s \leq t_i < s + t \}
+    = \sum_i \mathbb 1\{ s \leq t_i < s + t \}
 $$
 
 Suppose there are $k$ grid points between $s$ and $s+t$, so that $t \approx


### PR DESCRIPTION
Good evening @jstac , there is a redundant math notation ``V_i`` in
- \sum_i V_i \mathbb \{ s \leq t_i < s + t \}

Please find [here](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/poisson.md#uniqueness) (the 3rd equation above subsection **Uniqueness**).

I removed ``V_i`` here.