### PR TITLE
pos3_correction

### DIFF
--- a/ctmc_lectures/poisson.md
+++ b/ctmc_lectures/poisson.md
@@ -291,7 +291,7 @@ $$
     \text{Poisson}(k h \lambda )
 $$
 
-Using the fact that $kh = t_k \approx t$ when $k$ is large, we see
+Using the fact that $kh = t_k \approx t$ as $h \to 0$, we see
 that $\hat N_t$ is approximately Poisson with rate $t \lambda$, just as we
 expected.
 


### PR DESCRIPTION
Hi @jstac , this PR corrected a fact used in lecture ``poisson``, please find [here](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/poisson.md#uniqueness) (the 7th sentence above subsection **Uniqueness**), from
- ``Using the fact that $kh = t_k \approx t$ when $k$ is large``

to 
- ``Using the fact that $kh = t_k \approx t$ as $h \to 0$``,

aligned with the statement of this fact in lecture ``memoryless``, please find [here](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/memoryless.md#from-geometric-to-exponential).
