### PR TITLE
md1_issue_in_proof

### DIFF
--- a/ctmc_lectures/memoryless.md
+++ b/ctmc_lectures/memoryless.md
@@ -271,10 +271,10 @@ The discussion so far confirms that {eq}`implex` holds when $t$ is rational.
 So now take any $t \geq 0$ and rational sequences $(a_n)$ and $(b_n)$
 converging to $t$ with $a_n \leq t \leq b_n$ for all $n$.
 
-By property 1 we have $f(a_n) \leq f(t) \leq f(b_n)$ for all $n$, so
+By property 1 we have $f(b_n) \leq f(t) \leq f(a_n)$ for all $n$, so
 
 $$
-    f(1)^{a_n} \leq f(t) \leq f(1)^{b_n}
+    f(1)^{b_n} \leq f(t) \leq f(1)^{a_n}
     \quad \forall \, n \in \NN
 $$
 


### PR DESCRIPTION
Good afternoon, @jstac . This PR corrects an error in the proof of uniquely memoryless feature of the exponential distribution in lecture ``memoryless``, please see [here](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/memoryless.md#memoryless-property-of-the-exponential-distribution).

This is because
- ``Property 1`` states ``f is decreasing on \mathbb R_+``,
- you assume that ``a_n \leq t \leq b_n``,

then in the last several sentences of the proof, we should have 
- ``f(b_n) \leq f(t) \leq f(a_n)`` instead of ``f(a_n) \leq f(t) \leq f(b_n)`` and
- ``f(1)^{b_n} \leq f(t) \leq f(1)^{a_n}`` instead of ``f(1)^{a_n} \leq f(t) \leq f(1)^{b_n}``

This PR corrects this mistake.

Btw, @jstac , do you think we should add a symbol ``\square`` or ``\blacksquare`` at the end of proof to indicate the end of a proof?