### PR TITLE
md2_a_possible_improvement_solution1

### DIFF
--- a/ctmc_lectures/memoryless.md
+++ b/ctmc_lectures/memoryless.md
@@ -437,7 +437,7 @@ $$
     = e^{-\lambda(s + t)}
 $$
 
-At the same time,
+At the same time, $X > s-t$ if and only if $Y > s-t$. We get
 
 $$
     \PP\{X > s - t\}

--- a/ctmc_lectures/memoryless.md
+++ b/ctmc_lectures/memoryless.md
@@ -437,7 +437,7 @@ $$
     = e^{-\lambda(s + t)}
 $$
 
-At the same time, $X > s-t$ if and only if $Y > s-t$. We get
+At the same time, $X > s-t$ if and only if $Y > s-t$, so
 
 $$
     \PP\{X > s - t\}


### PR DESCRIPTION
Good afternoon, @jstac . This PR adds an expression ``$X > s-t$ if and only if $Y > s-t$. We get`` to the second case of solution 1 in lecture [memoryless](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/memoryless.md#solution-to-exercise-1).

I add it because I find the second case only holds when $t<s$, which is not specified in the proof.

Do you think it is an issue? 

If so, do you like the modification or another one we can add the condition ``$t < s$`` or else?