### PR TITLE
pp2_typos

### DIFF
--- a/ctmc_lectures/poisson.md
+++ b/ctmc_lectures/poisson.md
@@ -143,7 +143,7 @@ and the right hand side agrees with {eq}`poissondist` when $k=0$.
 This sets up a proof by induction, which is time consuming but not difficult
 --- the details can be found in $\S29$ of {cite}`howard2017elements`.
 
-Another way to show that $N_t$ is Poisson with rate $\lambda$ is appeal to 
+Another way to show that $N_t$ is Poisson with rate $\lambda$ appeals to 
 {proof:ref}`erlexp`.
 
 We observe that
@@ -374,7 +374,7 @@ An important consequence of stationary independent increments is the
 restarting property, which means that, when simulating, we can freely stop and
 restart a Poisson process at any time:
 
-```{proof:theorem} Poisson Processes can be Pause and Restarted
+```{proof:theorem} Poisson Processes can be Paused and Restarted
 If $(N_t)$ is a Poisson process, $s > 0$ and 
 $(M_t)$ is defined by $M_t = N_{s+t} - N_s$ for $t \geq 0$, then $(M_t)$ is a 
 Poisson process independent of $(N_r)_{r \leq s}$.


### PR DESCRIPTION
Hi @jstac , this PR corrects two potential typos in lecture [poison process](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/poisson.md).

- ``is appeal to`` -> ``appeals to``,
- ``be Pause`` -> ``be Paused``.