### PR TITLE
pp4_clarify_assumption

### DIFF
--- a/ctmc_lectures/poisson.md
+++ b/ctmc_lectures/poisson.md
@@ -204,6 +204,8 @@ and independent increments.
 
 This is due to the memoryless property of exponentials.
 
+Assume $I := \ZZ_+$.
+
 It means in particular that
 
 1. the variables $\{N_{t_{i+1}} - N_{t_i}\}_{i \in I}$ are independent for any


### PR DESCRIPTION
Good day, @jstac . This PR clarifies the assumption
- ``Assume  $I := \ZZ_+.$``,

which is needed to clarify set $I$ in the statement of the stationary independent increments, please see [here](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/poisson.md#stationary-independent-increments).