### PR TITLE
mp3_typos_in_math

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -157,7 +157,7 @@ The **joint distribution** of a Markov chain $(X_t)$ satisfying
 $S^\infty$ such that
 
 $$
-    \PP\{ X_{t_1} = y_1, \ldots, X_{t_k} = y_k \}
+    \PP\{ X_{t_1} = y_1, \ldots, X_{t_m} = y_m \}
     =
     \mathbf P_\psi\{ (x_t) \in S^\infty \,:\, 
         x_{t_i} = y_i \text{ for } i = 1, \ldots m\}


### PR DESCRIPTION
Hi, @jstac , this PR corrects a typo in equation (13) (or equivalent, equation jointdeq) in subsection ``The Joint Distribution`` of lecture [markov_prop](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md#the-joint-distribution):
- the ``k`` in expression ``\PP\{ X_{t_1} = y_1, \ldots, X_{t_k} = y_k \}`` should be ``m``, according to contexts.