### PR TITLE
mp4_update_link

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -122,7 +122,7 @@ In addition to connecting probabilities to the Markov matrix,
 {eq}`markovpropd` says that the process depends on its history only through
 the current state.
 
-We [recall that](https://python.quantecon.org/finite_markov.html), if $X_t$
+We [recall that](https://python.quantecon.org/finite_markov.html#Marginal-Distributions), if $X_t$
 has distribution $\phi$, then $X_{t+1}$ has distribution $\phi P$.
 
 Since $\phi$ is understood as a row vector, the meaning is


### PR DESCRIPTION
Hi @jstac , this PR updates the link attached to the recall part in lecture [markov_prop](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md#discrete-time-finite-state):
- from the lecture [finite_markov](https://python.quantecon.org/finite_markov.html) to [subsection Marginal Distribution of that lecture](https://python.quantecon.org/finite_markov.html#Marginal-Distributions), that is, the specific place with this recalled statement.