### PR TITLE
mp5_minor_edit

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -18,7 +18,7 @@ kernelspec:
 
 
 A continuous time stochastic process is said to have the Markov property if
-that the past and future are independent given the current state.
+its past and future are independent given the current state.
 
 (A more formal definition is provided below.)
 


### PR DESCRIPTION
Good evening, @jstac , this PR rephrases ``that the`` as ``its`` in the follow sentence of lecture [markov_prop](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md):

- ``A continuous time stochastic process is said to have the Markov property if
that the past and future are independent given the current state.``