### PR TITLE
mp7_clarify_Tonelli_theorem

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -227,7 +227,7 @@ $$
 $$ 
 
 (Swapping the order of infinite sums is justified here by the fact that all
-elements are nonnegative --- a version of Tonelli's theorem).
+elements are nonnegative --- a version of Tonelli's theorem, a successor of [Fubini's theorem](https://en.wikipedia.org/wiki/Fubini_theorem)).
 
 If $P$ and $Q$ are Markov matrices on $S$, then, using the definition in
 {eq}`kernprod`, 


### PR DESCRIPTION
Hi @jstac , this PR adds words about Fubini's theorem and a wiki link to clarify the Tonelli's theorem in subsection ``Extending to Countable State Space`` of [markov_prop](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md#extending-to-countable-state-spaces):
- ``a version of Tonelli's theorem`` -> ``a version of Tonelli's theorem, a successor of [Fubini's theorem](https://en.wikipedia.org/wiki/Fubini_theorem)``.