### PR TITLE
mp8_rephrasing

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -268,13 +268,13 @@ to the current setting.
 
 ### The Continuous Time Case
 
-A **continuous time stochastic process** on $S$ is a collection $(X_t)$ of $S$-valued
+A **continuous time stochastic process** on $S$, $(X_t)$, is a collection of $S$-valued
 random variables $X_t$ defined on a common probability space and indexed by $t
 \in \RR_+$.
 
 Let $I$ be the Markov matrix on $S$ defined by $I(x,y) = \mathbb 1\{x = y\}$.
 
-A **Markov semigroup** is a family $(P_t)$ of Markov matrices
+A **Markov semigroup** $(P_t)$ is a family of Markov matrices
 on $S$ satisfying 
 
 1. $P_0 = I$,


### PR DESCRIPTION
Good morning @jstac , this PR shifts the locations of notations in subsection [The Continuous Time Case](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md#the-continuous-time-case) of ``markov_prop``:
- ``A **continuous time stochastic process** on $S$ is a collection $(X_t)$ of $S$-valued
random variables $X_t$ defined on a common probability space and indexed by $t
\in \RR_+$.`` -> ``A **continuous time stochastic process** on $S$, $(X_t)$, is a collection of $S$-valued
random variables $X_t$ defined on a common probability space and indexed by $t
\in \RR_+$.``,
- ``A **Markov semigroup** is a family $(P_t)$ of Markov matrices
on $S$ satisfying`` -> ``A **Markov semigroup** $(P_t)$ is a family of Markov matrices
on $S$ satisfying``.
