### PR TITLE
mp9_clarify_finite_dimensiional_distributions

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -333,7 +333,7 @@ initial condition.
 This distribution is defined over the set of all right continuous functions
 $\RR_+ \ni t \mapsto x_t \in S$, which we call $rcS$.
 
-Next one builds finite dimensional distributions over $rcS$ using
+Next one builds [finite dimensional distributions](https://en.wikipedia.org/wiki/Finite-dimensional_distribution) over $rcS$ using
 expressions similar to {eq}`mathjointd`.
 
 Finally, the Kolmogorov extension theorem is applied, similar to the discrete


### PR DESCRIPTION
Hi @jstac , this PR adds a link (https://en.wikipedia.org/wiki/Finite-dimensional_distribution) to clarify ``finite-dimensional distributions`` in subsection [The Continuous Time Case](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md#the-continuous-time-case) of markov_prop.