### PR TITLE
mp10_clarify_functional

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -355,8 +355,8 @@ condition $\psi$.
 Next, create the corresponding joint distribution $\mathbf P_\psi$ over
 $rcS$, as described above.
 
-Now, for each $t \geq 0$, let $\pi_t$ be the [point evaluation functional](https://en.wikipedia.org/wiki/Functional_(mathematics)) on
-$rcS$, that maps right continuous function $(x_\tau)$ into its time $t$ value
+Now, for each $t \geq 0$, let $\pi_t$ be the time $t$ projection on
+$rcS$, which maps any right continuous function $(x_\tau)$ into its time $t$ value
 $x_t$.
 
 Finally, let $X_t$ be an $S$-valued function on $rcS$ defined at $(x_\tau) \in rcS$ by $\pi_t ( (x_\tau))$.

--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -355,7 +355,7 @@ condition $\psi$.
 Next, create the corresponding joint distribution $\mathbf P_\psi$ over
 $rcS$, as described above.
 
-Now, for each $t \geq 0$, let $\pi_t$ be the point evaluation functional on
+Now, for each $t \geq 0$, let $\pi_t$ be the [point evaluation functional](https://en.wikipedia.org/wiki/Functional_(mathematics)) on
 $rcS$, that maps right continuous function $(x_\tau)$ into its time $t$ value
 $x_t$.
 


### PR DESCRIPTION
Hi @jstac , this PR adds a wiki link (https://en.wikipedia.org/wiki/Functional_(mathematics)) to clarify ``point evaluation functional`` in subsection [The Canonical Chain](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md#the-canonical-chain) of ``markov_prop``.