### PR TITLE
mp11_typo

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -399,7 +399,7 @@ formal discussion.
 
 Let $(X_t)$ be a continuous time stochastic process with state space $S = \{0, 1\}$.
 
-The process starts at $0$ and updates at follows:
+The process starts at $0$ and updates as follows:
 
 1. Draw $W$ independently from a fixed Pareto distribution.
 1. Hold $(X_t)$ in its current state for $W$ units of time and then switch


### PR DESCRIPTION
Hi @jstac , this PR corrects a small typo in subsection [Example: Failure of the Markov Property](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md#example-failure-of-the-markov-property) of markov_prop:
- ``The process starts at 0 and updates at follows:`` -> ``The process starts at 0 and updates as follows:``