### PR TITLE
mp13_add_summation

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -784,7 +784,7 @@ $$
     \PP\{X_{s + t} = y \,|\, \fF_s \}
     = \sum_{k \geq 0}
     K^k(Y_{N_s}, y) \frac{(t \lambda )^k}{k!} e^{-t \lambda}
-    = K^k(X_s, y) \frac{(t \lambda )^k}{k!} e^{-t \lambda}
+    = \sum_{k \geq 0} K^k(X_s, y) \frac{(t \lambda )^k}{k!} e^{-t \lambda}
 $$
 
 Since the expression above depends only on $X_s$,


### PR DESCRIPTION
Hi @jstac , this PR adds a missing summation notation, ``\sum_{k \geq 0}``,  in the RHS of the second equality of the following math expression in subsection [markov-property-1](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md#markov-property-1) of lecture ``markov_prop``:
- ``\PP\{X_{s + t} = y \,|\, \fF_s \}
    = \sum_{k \geq 0}
    K^k(Y_{N_s}, y) \frac{(t \lambda )^k}{k!} e^{-t \lambda}
    = K^k(X_s, y) \frac{(t \lambda )^k}{k!} e^{-t \lambda}``