### PR TITLE
mp16_clarify_the_limit

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -867,7 +867,7 @@ $$
     \qquad (x \in S)
 $$
 
-Then $\hat \psi_t(x)$ will be close to $\PP\{X_t = x\}$ by the law of
+Then as $M \to \infty$, $\hat \psi_t(x)$ will be close to $\PP\{X_t = x\}$ by the law of
 large numbers.
 
 In other words, in the limit we recover $\psi_t$.

--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -867,7 +867,7 @@ $$
     \qquad (x \in S)
 $$
 
-Then as $M \to \infty$, $\hat \psi_t(x)$ will be close to $\PP\{X_t = x\}$ by the law of
+When $M$ is large, $\hat \psi_t(x)$ will be close to $\PP\{X_t = x\}$ by the law of
 large numbers.
 
 In other words, in the limit we recover $\psi_t$.


### PR DESCRIPTION
Hi @jstac , this PR adds ``as $M \to \infty, $`` in the following sentence to clarify the limit condition of the equation in subsection [distribution-flows-for-the-inventory-model](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md#distribution-flows-for-the-inventory-model) in lecture markov_prop:
- ``Then $\hat \psi_t(x)$ will be close to $\PP\{X_t = x\}$ by the law of large numbers.``