### PR TITLE
mp17_delete_redundant_full_stop

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -935,7 +935,7 @@ distribution $\mathbf P_\psi^n$.
 
 ### Exercise 4
 
-Try to produce your own version of the figure {ref}`flow_fig`.
+Try to produce your own version of the figure {ref}`flow_fig`
 
 The initial condition is ``ψ_0 = binom.pmf(states, n, 0.25)`` where ``n = b + 1``.
 


### PR DESCRIPTION
Hi @jstac , this PR deletes a redundant full stop in the following sentence of [Exercise 4](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md#exercise-4) of lecture markov_prop:
- ``Try to produce your own version of the figure {ref}`flow_fig`.``

The full stop is included in the figure reference, please see [here](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md#distribution-flows-for-the-inventory-model).