### PR TITLE
mp18_correct_proof_ex3

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -1019,13 +1019,13 @@ From the Markov property and the induction hypothesis, the right hand side is
 
 $$
     P (x_{n-1}, x_n )
-    \mathbf P_\psi^n(x_0, x_1, \ldots, x_{n-1})
+    \mathbf P_\psi^{n-1}(x_0, x_1, \ldots, x_{n-1})
     =
-        P (x_n, x_{n+1} )
+        P (x_{n-1}, x_n )
         \psi(x_0)
         P(x_0, x_1)
         \times \cdots \times
-        P(x_{n-1}, x_{n-1})
+        P(x_{n-2}, x_{n-1})
 $$
 
 The last expression equals $\mathbf P_\psi^n$, which concludes the proof.


### PR DESCRIPTION
Good morning @jstac , this PR corrects some errors in the proof of [Exercise 3](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md#solution-to-exercise-3) of lecture markov_prop:
- ``P (x_{n-1}, x_n ) \mathbf P_\psi^n(x_0, x_1, \ldots, x_{n-1}) =
        P (x_n, x_{n+1} )
        \psi(x_0)
        P(x_0, x_1)
        \times \cdots \times
        P(x_{n-1}, x_{n-1})`` --->>>

- ``P (x_{n-1}, x_n ) \mathbf P_\psi^{n-1}(x_0, x_1, \ldots, x_{n-1}) =
        P (x_{n-1}, x_n )
        \psi(x_0)
        P(x_0, x_1)
        \times \cdots \times
        P(x_{n-2}, x_{n-1})``