### PR TITLE
kbe2_minor_typo

### DIFF
--- a/ctmc_lectures/kolmogorov_bwd.md
+++ b/ctmc_lectures/kolmogorov_bwd.md
@@ -360,7 +360,7 @@ $$
 
 In other words, each $P_t$ has unit row sums. 
 
-Next we check positivity of all elements of $P_t$ (which can easily fail for
+Next we check nonnegativity of all elements of $P_t$ (which can easily fail for
 matrix exponentials).
 
 To this end, adopting an argument from {cite}`stroock2013introduction`, we


### PR DESCRIPTION
Hi @jstac , this PR corrects two possible minor typos in lecture [kolmogorov_bwd](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/kolmogorov_bwd.md#overview):
- ``This assumption was made purely for convenience and seems unlikely to hold true.`` -->> ``This assumption was made purely for convenience and seemed unlikely to hold true.``
- ``Next we check positivity of all elements of P_t (which can easily fail for`` -> ``Next we check nonnegativity of all elements of P_t (which can easily fail for``