### PR TITLE
kbe5_adjust_fontsize_of_figure's_xaxis

### DIFF
--- a/ctmc_lectures/kolmogorov_bwd.md
+++ b/ctmc_lectures/kolmogorov_bwd.md
@@ -481,7 +481,7 @@ draws = independent_draws(T, num_draws=100_000)
 fig, ax = plt.subplots()
 
 ax.bar(range(n), [np.mean(draws == i) for i in range(n)], width=0.8, alpha=0.6)
-ax.set(xlabel="inventory")
+ax.set_xlabel("inventory", fontsize=14)
 
 plt.show()
 ```
@@ -565,7 +565,7 @@ def P_t(ψ, t):
 fig, ax = plt.subplots()
 
 ax.bar(range(n), ψ_T, width=0.8, alpha=0.6)
-ax.set(xlabel="inventory")
+ax.set_xlabel("inventory", fontsize=14)
 
 plt.show()
 ```


### PR DESCRIPTION
Hi @jstac , this PR adjusts the label fontsize of 2 figures' x-axis in lecture [komogorov_bwd](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/kolmogorov_bwd.md#an-integral-equation) and sets it to ``14``:
- ``ax.set(xlabel="inventory")`` -> ``ax.set_xlabel("inventory", fontsize=14)``