### PR TITLE
kbe6_title_consistent

### DIFF
--- a/ctmc_lectures/kolmogorov_bwd.md
+++ b/ctmc_lectures/kolmogorov_bwd.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 ---
 
-# Kolmogorov Backward Equation
+# The Kolmogorov Backward Equation
 
 ## Overview 
 


### PR DESCRIPTION
Hi @jstac , this PR modifies the title of lecture [kolmogorov_bwd](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/kolmogorov_bwd.md) as ``The Kolmogorov Backward Equation``, aligned with the title of lecture [kolmogorov_bwd](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/kolmogorov_fwd.md), ``The Kolmogorov Forward Equation``.