### PR TITLE
kfe1_clarify_unit_simplex

### DIFF
--- a/ctmc_lectures/kolmogorov_fwd.md
+++ b/ctmc_lectures/kolmogorov_fwd.md
@@ -85,8 +85,8 @@ $$
 
 where distributions are understood as row vectors.
 
-Here's a visualization for the case $S = \{0, 1, 2\}$, so that $\dD$ is the unit
-simplex in $\RR^3$.
+Here's a visualization for the case $S = \{0, 1, 2\}$, so that $\dD$ is the [standard
+simplex](https://en.wikipedia.org/wiki/Simplex#The_standard_simplex) in $\RR^3$.
 
 The initial condition is `` (0, 0, 1)`` and the Markov matrix is
 


### PR DESCRIPTION
Hi @jstac , this PR adds the following wiki link to clarify ``unit simplex`` in the subsection [Review of the Discrete Time Case](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/kolmogorov_fwd.md#review-of-the-discrete-time-case) of lecture kolmogorov_fwd:
- https://en.wikipedia.org/wiki/Simplex