### PR TITLE
kbe7_clarify_vector_1

### DIFF
--- a/ctmc_lectures/kolmogorov_bwd.md
+++ b/ctmc_lectures/kolmogorov_bwd.md
@@ -340,7 +340,8 @@ $$
     = 0
 $$
 
-As a small exercise, you can check that the following is true
+As a small exercise, you can check that, with $1$
+representing a column vector of ones, the following is true
 
 $$
     Q \text{ has zero row sums }


### PR DESCRIPTION
Hi @jstac , this PR adds the following sentence to clarify column-vector-of-ones ``1`` in the [proof of lemma 9 of lecture kolmogorov_bwd](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/kolmogorov_bwd.md#checking-the-transition-semigroup-properties):
- ``with $1$
as a column vector of ones``.

@jstac , I noticed that you use the same notations for a real number ``1`` and a column-vector-of-ones ``1`` in this lecture and the following lectures.

Do you think we should use another notation to clarify the column-vector-of-ones to distinguish these two?