### PR TITLE
[generators]1_typos2

### DIFF
--- a/ctmc_lectures/generators.md
+++ b/ctmc_lectures/generators.md
@@ -38,7 +38,7 @@ Such technicalities are hard to avoid, since so many interesting Markov chains
 do have infinite state spaces.
 
 * Our very first example -- the Poisson process -- has an infinite state space.
-* Another example is the study of queues, which often have no natural upper
+* Another example is the study of queues, which often has no natural upper
 bound.[^footnotepp]
 
 [^footnotepp]: In fact a major concern with queues is that their length does not explode. This issue cannot be properly explored unless the state space is allowed to be infinite.
@@ -62,7 +62,7 @@ $$ (abscp)
 
 where 
 
-* $x_t$ takes value in a Banach space at each time $t$,
+* $x_t$ takes a value in a Banach space at each time $t$,
 * $A$ is a linear operator and
 * the time derivative $x'_t$ uses a definition appropriate for a Banach
   space.


### PR DESCRIPTION
Hi @jstac , this PR corrects two possible typos in lecture [generators](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/generators.md):
- ``Another example is the study of queues, which often have no natural upper bound.`` -->> ``Another example is the study of queues, which often has no natural upper bound.``
- ``$x_t$ takes value in  a Banach space at each time $t$`` -->> ``$x_t$ takes a value in  a Banach space at each time $t$``