### PR TITLE
[generators]2_clarify_banach_space

### DIFF
--- a/ctmc_lectures/generators.md
+++ b/ctmc_lectures/generators.md
@@ -43,7 +43,7 @@ bound.[^footnotepp]
 
 [^footnotepp]: In fact a major concern with queues is that their length does not explode. This issue cannot be properly explored unless the state space is allowed to be infinite.
 
-Readers are assumed to have some basic familiarity with Banach spaces.
+Readers are assumed to have some basic familiarity with [Banach spaces](https://en.wikipedia.org/wiki/Banach_space).
 
 ## Motivation
 


### PR DESCRIPTION
Good morning, @jstac , this PR adds a wiki link (https://en.wikipedia.org/wiki/Banach_space) to clarify the first-appearing ``Banach spaces`` in lecture [generators](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/generators.md).