### PR TITLE
[generators]3_relocate_clarification

### DIFF
--- a/ctmc_lectures/generators.md
+++ b/ctmc_lectures/generators.md
@@ -138,8 +138,8 @@ and so on.
 
 We write $A B$ to indicate composition of the operators $A, B \in \linop$.
 
-The value defined in {eq}`norml` is called the **operator norm** of $A$ and,
-as suggested by the notation, [is a norm](https://en.wikipedia.org/wiki/Operator_norm) on $\linop$.
+The value defined in {eq}`norml` is called the [**operator norm**](https://en.wikipedia.org/wiki/Operator_norm) of $A$ and,
+as suggested by the notation, is a norm on $\linop$.
 
 In addition to being a norm, it enjoys the submultiplicative property $\| AB
 \| \leq \| A \| \| B\|$ for all $A, B \in \linop$.


### PR DESCRIPTION
Dear @jstac , this PR relocates the wiki link (https://en.wikipedia.org/wiki/Operator_norm), which originally clarified ``is a norm``, to clarify ``operator norm`` in lecture [generators](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/generators.md).