### PR TITLE
[generators]5_rephrase

### DIFF
--- a/ctmc_lectures/generators.md
+++ b/ctmc_lectures/generators.md
@@ -359,7 +359,7 @@ Indeed, why should the limit exist, given that $C_0$ semigroups are not
 required to be differentiable?
 
 The other problem is that, even though the limit exists, the linear operator
-$A$ is not bounded (i.e., not an element of $\linop$), so 
+$A$ might be unbounded (i.e., not an element of $\linop$), in which case 
 a statement like $U_t = e^{tA}$ is problematic.
 
 It turns out that, despite these issues, the theory of $C_0$ semigroups is


### PR DESCRIPTION
Hi @jstac , this PR makes the following change in lecture [generators](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/generators.md):
- ``A is not bounded`` -->> ``A may be not bounded``

The original tone can be too strong in the context. 