### PR TITLE
[generators]7_delete_a_problematic_space

### DIFF
--- a/ctmc_lectures/generators.md
+++ b/ctmc_lectures/generators.md
@@ -516,7 +516,7 @@ The solution is similar to that of the previous exercise.
 Let $(U_t)$ be an evolution semigroup satisfying {eq}`czsg3`,
 fix $t > 0$ and take $(h_n)$ to be a scalar sequence satisfying $h_n \downarrow 0$.  
 
-On one hand, $U_{t+ h_n} = U_{h_n} U_t \to U_t $ by {eq}`czsg3`.
+On one hand, $U_{t+ h_n} = U_{h_n} U_t \to U_t$ by {eq}`czsg3`.
 
 On the other hand, from the submultiplicative property of the operator norm
 and {eq}`sgbound`,


### PR DESCRIPTION
Good morning @jstac , this PR deletes a problematic `` ``(space) in a math expression in solution 3 of lecture [generators](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/generators.md#solutions).

This space would make the latex math expression unable to be compiled.