### PR TITLE
[generators]8_keep_semigroup_notation_consistent

### DIFF
--- a/ctmc_lectures/generators.md
+++ b/ctmc_lectures/generators.md
@@ -333,7 +333,7 @@ $$
 $$
 
 In the more abstract setting of $C_0$ semigroups, we say that $Q$ is the
-"generator" of the semigroup $P_t$.
+"generator" of the semigroup $(P_t)$.
 
 More generally, given a $C_0$ semigroup $(U_t)$, we say that a linear
 operator $A$ from $\BB$ to itself is the **generator** of $(U_t)$ if 


### PR DESCRIPTION
Good day @jstac , this PR adds a pair of brackets ``()`` to the notation of semigroup ``$P_t$`` to make it consistent with all other semigroup notations in lecture [generators](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/generators.md).