### PR TITLE
[generators]10_correct_or_clarify

### DIFF
--- a/ctmc_lectures/generators.md
+++ b/ctmc_lectures/generators.md
@@ -223,7 +223,7 @@ when $S$ is finite, we introduced the derivative of a map $t
 The derivative was defined by differentiating $P_t$ element-by-element.
 
 This coincides with the operator-theoretic definition in {eq}`devlim` when $S$
-is finite, because then the space $\lL(\ell_1)$ is finite dimensional, and
+is finite, because then the space $\lL(\ell_1)$, which consists of all bounded linear operators on $\ell_1$, is finite dimensional, and
 hence pointwise and norm convergence coincide.
 ```
 


### PR DESCRIPTION
Hi @jstac , this PR corrects the following possible typo in lecture [generators](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/generators.md):
- ``\lL(\ell_1)``(L(l_1)) -->> ``\linop`` (L(B))

Even if ``\lL(\ell_1)`` is correct here, since it appears without defining first (we define ``\lL(\ell_1)`` in the next lecture [uc_mc_semigroups](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/uc_mc_semigroups.md)), we'd better add a clarification.
