### PR TITLE
[uc_mc_semigroups]2_error_above_theorem17

### DIFF
--- a/ctmc_lectures/uc_mc_semigroups.md
+++ b/ctmc_lectures/uc_mc_semigroups.md
@@ -105,7 +105,7 @@ Since $Q$ is in $\linopell$, the operator exponential $e^{tQ}$ is well defined
 as an element of $\linopell$ for all $t \geq 0$.
 
 Moreover, by {proof:ref}`ecuc`, the family $(P_t)$ in $\lL(\ell_1)$ defined by
-$P_t = e^{tQ}$ defines a UC Markov semigroup on $S$.
+$P_t = e^{tQ}$ defines a UC Markov semigroup on $\ell_1$.
 
 (Here, a Markov semigroup $(P_t)$ is both a collection of Markov matrices and a
 collection of operators, as in {eq}`mmismo`.)


### PR DESCRIPTION
Dear @jstac , this PR corrects an error in the following sentence of lecture [uc_mc_semigroups](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/uc_mc_semigroups.md):
- ``the family $(P_t)$ in $\lL(\ell_1)$ defined by $P_t = e^{tQ}$ defines a UC Markov semigroup on $S$``

where ``$S$`` should be ``$\ell_1$`` according to the contexts.