### PR TITLE
[uc_mc_semigroups]3_missing_minus_sign_in_math_example18

### DIFF
--- a/ctmc_lectures/uc_mc_semigroups.md
+++ b/ctmc_lectures/uc_mc_semigroups.md
@@ -216,8 +216,8 @@ For given $t \geq 0$, we then have
 $$
     e^{tQ}
     = e^{\lambda t (K-I)}
-    = e^{\lambda t} e^{\lambda t K}
-    = e^{\lambda t} 
+    = e^{-\lambda t} e^{\lambda t K}
+    = e^{-\lambda t} 
     \sum_{m \geq 0} \frac{(\lambda t K)^m}{m!}
 $$
 
@@ -229,9 +229,9 @@ Inserting this expression for $K^m$ leads to
 
 $$
     e^{tQ}(i, j)
-    = e^{\lambda t} 
+    = e^{-\lambda t} 
     \sum_{m \geq 0} \frac{(\lambda t )^m}{m!} \mathbb 1\{j = i + m\}
-    = e^{\lambda t} 
+    = e^{-\lambda t} 
     \sum_{m \geq 0} \frac{(\lambda t )^m}{m!} \mathbb 1\{m = j-i\}
 $$
 


### PR DESCRIPTION
Hi @jstac , this PR adds missing ``-`` signs for some math expressions in ``Example 18`` (The example above subsection ``A Necessary and Sufficient Condition`` of lecture [uc_mc_semigroups](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/uc_mc_semigroups.md).

The error comes from a derivation:
- ``e^{\lambda t (K-I)} = e^{\lambda t} e^{\lambda t K}``

where ``e^{\lambda t}`` should be ``e^{-\lambda t}``.