### PR TITLE
[uc_mc_semigroups]5_add_missing_equality_signs_in_solution1

### DIFF
--- a/ctmc_lectures/uc_mc_semigroups.md
+++ b/ctmc_lectures/uc_mc_semigroups.md
@@ -560,8 +560,8 @@ Clearly $\phi P \geq 0$, and
 
 $$
     \sum_y (\phi P)(y)
-    \sum_y \sum_x \phi (x) P(x, y)
-    \sum_x \phi (x) \sum_y P(x, y)
+    =\sum_y \sum_x \phi (x) P(x, y)
+    =\sum_x \phi (x) \sum_y P(x, y)
     = 1
 $$
 


### PR DESCRIPTION
Dear @jstac , this PR adds all missing ``=`` for the last math expression in ``Solution 1`` of lecture [uc_mc_semigroups](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/uc_mc_semigroups.md).