### PR TITLE
[uc_mc_semigroups]6_correct_errors_in_solution4

### DIFF
--- a/ctmc_lectures/uc_mc_semigroups.md
+++ b/ctmc_lectures/uc_mc_semigroups.md
@@ -639,8 +639,8 @@ We then have, by definition of composition (matrix multiplication),
 $$
     K^{m+1}(i, j)
     = \sum_n K(i, n) K^m (n, j)
-    = \sum_n K(i, n) \mathbb 1\{j = i + m\}
-    = K(i, m-j)
+    = \sum_n K(i, n) \mathbb 1\{j = n + m\}
+    = K(i, j-m)
 $$
 
 Applying the definition $K(i, j) = \mathbb 1\{j = i + 1\}$ completes verification of the claim.


### PR DESCRIPTION
Hi @jstac , this PR corrects errors in the following math expression of lecture [uc_mc_semigroups](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/uc_mc_semigroups.md)'s ``Solution 4``:
- ``K^{m+1}(i, j) = \sum_n K(i, n) K^m (n, j) = \sum_n K(i, n) \mathbb 1\{j = i + m\} = K(i, m-j)`` -->> ``K^{m+1}(i, j) = \sum_n K(i, n) K^m (n, j) = \sum_n K(i, n) \mathbb 1\{j = n + m\} = K(i, j-m)``