### PR TITLE
[ergodicity]2_add_(P_t)

### DIFF
--- a/ctmc_lectures/ergodicity.md
+++ b/ctmc_lectures/ergodicity.md
@@ -72,7 +72,7 @@ This means that if $X_t$ has distribution $\psi$, then so does $X_{t+1}$.
 
 For continuous time Markov chains, the definition is analogous.
 
-Given a Markov semigroup on $S$, a distribution $\psi^* \in \dD$ is called
+Given a Markov semigroup $(P_t)$ on $S$, a distribution $\psi^* \in \dD$ is called
 **stationary** for $(P_t)$ if
 
 $$


### PR DESCRIPTION
Good afternoon, @jstac , this PR adds ``$(P_t)$`` after ``a Markov semigroup`` to clarify it in lecture [ergodicity](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/ergodicity.md).