### PR TITLE
[ergodicity]5_clarify_side_limit

### DIFF
--- a/ctmc_lectures/ergodicity.md
+++ b/ctmc_lectures/ergodicity.md
@@ -227,9 +227,9 @@ $$
 $$
 
 Since $(P_t)$ is UC and $Q$ is its generator, we have $\| D_t - Q \| \to 0$ in
-$\lL(\ell_1)$ as $t \to 0$.
+$\lL(\ell_1)$ as $t \to 0^+$.
 
-Hence $\| \psi Q \| \leq \liminf_{t \to 0} \| \psi D_t \|$.
+Hence $\| \psi Q \| \leq \liminf_{t \downarrow 0} \| \psi D_t \|$.
 
 As $\psi$ is stationary for $(P_t)$, we have $\psi D_t = 0$ for all $t$.
 


### PR DESCRIPTION
Hi @jstac , this PR makes following changes to clarify one-side limit, aligned with your previous notation, in lecture [ergodicity](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/ergodicity.md):
- ``$t \to 0$`` -->> ``$t \to 0^+$``,
- ``$\| \psi Q \| \leq \liminf_{t \to 0} \| \psi D_t \|$`` -->> ``$\| \psi Q \| \leq \liminf_{t \downarrow 0} \| \psi D_t \|$``