### PR TITLE
[ergodicity]6_clarify_states_x_y_in_S

### DIFF
--- a/ctmc_lectures/ergodicity.md
+++ b/ctmc_lectures/ergodicity.md
@@ -240,7 +240,7 @@ Hence $\psi Q = 0$, as was to be shown.
 
 ## Irreducibility and Uniqueness
 
-Let $(P_t)$ be a Markov semigroup on $S$.
+Let $(P_t)$ be a Markov semigroup on $S$ and consider arbitrary states $x, y \in S$.
 
 We say that state $y$ is **accessible** from state $x$ if
 there exists a $t \geq 0$ such that $P_t(x, y) > 0$.


### PR DESCRIPTION
Hi @jstac , this PR makes the following change to clarify states x and y in lecture [ergodicity](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/ergodicity.md):
- ``Let $(P_t)$ be a Markov semigroup on $S$.`` -->> ``Let $(P_t)$ be a Markov semigroup on $S$ and consider arbitrary states $x, y \in S$.``