### PR TITLE
[ergodicity]7_clarify_absorbing_set

### DIFF
--- a/ctmc_lectures/ergodicity.md
+++ b/ctmc_lectures/ergodicity.md
@@ -448,7 +448,7 @@ See, for example, Proposition 3.1.2 of {cite}`lasota1994chaos` or Lemma 8.2.3 of
 ### Uniqueness
 
 Irreducibility of a given Markov chain implies that there are no disjoint
-absorbing sets.
+[absorbing sets](https://en.wikipedia.org/wiki/Absorbing_set).
 
 This in turn leads to uniqueness of stationary distributions:
 


### PR DESCRIPTION
Dear @jstac , this PR adds a wiki link (https://en.wikipedia.org/wiki/Absorbing_set) to clarify ``absorbing set`` in lecture [ergodicity](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/ergodicity.md).