### PR TITLE
[ergodicity]8_fix_full_stop_issues

### DIFF
--- a/ctmc_lectures/ergodicity.md
+++ b/ctmc_lectures/ergodicity.md
@@ -544,10 +544,10 @@ $$
     \| \psi P_t - \psi^* \|
     = \| \psi P_{sn} P_h - \psi^* P_h \|
     \leq \| \psi P_{sn} - \psi^* \|
-    < \epsilon.
+    < \epsilon
 $$
 
-Hence asymptotic stability holds
+Hence asymptotic stability holds for $(P_t)$.
 
 ```
 


### PR DESCRIPTION
Hi @jstac , this PR 
- deletes an unnecessary ``.`` in the math expression ``\| \psi P_t - \psi^* \|= \| \psi P_{sn} P_h - \psi^* P_h \| \leq \| \psi P_{sn} - \psi^* \| < \epsilon``
- changes ``Hence asymptotic stability holds`` -->> ``Hence asymptotic stability holds for $(P_t)$.``

in lecture [ergodicity](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/ergodicity.md).