### PR TITLE
[ergodicity]9_modify_v(i)_to_v(j)

### DIFF
--- a/ctmc_lectures/ergodicity.md
+++ b/ctmc_lectures/ergodicity.md
@@ -596,8 +596,8 @@ Suppose that $\lambda < \mu$.
 It is intuitive that, in this case, the queue length will not 
 tend to infinity (since the service rate is higher than the arrival rate).
 
-This intuition can be confirmed via {proof:ref}`sdrift`, after setting $v(i) =
-i$.
+This intuition can be confirmed via {proof:ref}`sdrift`, after setting $v(j) =
+j$.
 
 Indeed, we have, for any $i \geq 1$,
 


### PR DESCRIPTION
Hi @jstac , this PR changes ``$v(i) =
i$`` to ``$v(j) =
j$``, aligned with its following math expressions in lecture [ergodicity](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/ergodicity.md).