### PR TITLE
[ergodicity]10_add_condition_for_M

### DIFF
--- a/ctmc_lectures/ergodicity.md
+++ b/ctmc_lectures/ergodicity.md
@@ -607,7 +607,7 @@ $$
     = \lambda - \mu
 $$
 
-Setting $F=\{0\}$ and $\epsilon = \mu - \lambda$, we see that the conditions
+Setting $F=\{0\}$ and $M = \lambda - \mu = - \epsilon$, we see that the conditions
 of {proof:ref}`sdrift` hold.
 
 Hence the associated semigroup $(P_t)$ is asymptotically stable.


### PR DESCRIPTION
Good afternoon, @jstac , this PR makes the following change in [example 31 of ergodicity](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/ergodicity.md#stability-via-drift):
- ``Setting $F=\{0\}$ and $\epsilon = \mu - \lambda$`` -->> ``Setting $F=\{0\}$ and $M = \lambda - \mu = - \epsilon$``

It seems that the origin contexts do not specify the condition for $M$, which is needed when using Theorem 30.