### PR TITLE
[ergodicity]11_error_in_solution2 (More Discussion Required)

### DIFF
--- a/ctmc_lectures/ergodicity.md
+++ b/ctmc_lectures/ergodicity.md
@@ -666,12 +666,12 @@ The statement is true.  With $t=0$ we have $P_t(x,x) = I(x,x) = 1 > 0$.
 
 Suppose to the contrary that $\phi \in \dD$ and $\phi Q = 0$.
 
-Then 
+Then, for any $j \geq 1$,
 
 $$
     (\phi Q)(j) 
     = \sum_{i \geq 0} \phi(i) Q(i, j)
-    = - \lambda_j \phi(j) + \lambda_j \phi(j+1) 
+    = - \lambda_j \phi(j) + \lambda_{j-1} \phi(j-1) 
     = 0
 $$
 


### PR DESCRIPTION
Dear @jstac , for solution 2 of lecture [ergodicity](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/ergodicity.md), this PR corrects a mistake and adds a condition to clarify its holding:
- $(\phi Q)(j) = \sum_{i \geq 0} \phi(i) Q(i, j) = - \lambda_j \phi(j) + \lambda_{j} \phi(j) = 0$ -->> $(\phi Q)(j) = \sum_{i \geq 0} \phi(i) Q(i, j) = - \lambda_j \phi(j) + \lambda_{j-1} \phi(j-1) = 0$
- ``Then`` -->> ``Then, for any $j \geq 1$,``

Note that $\phi Q$ is a forward equation and because of the [definition](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/ergodicity.md#exercises) of ``Q``, we have the corrected math expression above.

However, this brings us a new issue that the statement after this math expression, ``It follows that $\phi$ is constant on $\ZZ_+$.``, may not hold.
- This statement holds if we consider a special case of the pure birth process: when $\lambda_i=\lambda$ for all $i$.

I am still thinking about a way to fix the new issue, and this may require further discussion and corrections.

@jstac , what do you think?