### PR TITLE
[markov_prop]&[kolmogorov_bwd]add undefined label: markov_prop

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -12,6 +12,7 @@ kernelspec:
   name: python3
 ---
 
+(markov_prop)=
 # The Markov Property 
 
 ## Overview


### PR DESCRIPTION
Dear @jstac , this PR addes undefined label ``markov_prop`` on lecture [markov_prop](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md), because this label has been mentioned twice in lecture [kolmogorov_bwd](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/kolmogorov_bwd.md).