### PR TITLE
[markov_prop]&[uc_mc_semigroup]correct an undefined label

### DIFF
--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -381,7 +381,7 @@ Fortunately, it turns out that there are more concrete ways to build
 continuous time Markov chains from the objects that describe their
 distributions.
 
-We will learn about these in a {doc}`later lecture <prob_view>`.
+We will learn about these in a {doc}`later lecture <ucmc>`.
 
 
 

--- a/ctmc_lectures/uc_mc_semigroups.md
+++ b/ctmc_lectures/uc_mc_semigroups.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 ---
 
-
+(ucmc)=
 # UC Markov Semigroups
 
 ## Overview


### PR DESCRIPTION
Hi @jstac , there is an undefined label ``prob_view`` intending to link to an unknown lecture (according to contexts, it can be lecture ``uc_mc_semigroup``.

This PR 
- labels the lecture [uc_mc_semigroup](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/uc_mc_semigroups.md) by ``ucmc``,
- changes the label ``prob_view`` in lecture [markov_prop](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/markov_prop.md) to ``ucmc``.