### PR TITLE
[ergodicity]fix_proof_ex2

### DIFF
--- a/ctmc_lectures/ergodicity.md
+++ b/ctmc_lectures/ergodicity.md
@@ -634,7 +634,7 @@ for this semigroup, every state $x$ is accessible from itself.
 
 ### Exercise 2
 
-Let $(\lambda_k)$ be a bounded sequence in $(0, \infty)$.
+Let $(\lambda_k)$ be a bounded non-increasing sequence in $(0, \infty)$.
 
 A **pure birth process** starting at zero is a continuous time Markov process
 $(X_t)$ on state space $\ZZ_+$ with intensity matrix
@@ -675,9 +675,21 @@ $$
     = 0
 $$
 
-It follows that $\phi$ is constant on $\ZZ_+$.
+Since $(\lambda_k)$ is non-increasing, it follows that
 
-But $\dD$ contains no constant functions when the state space is infinite.
+$$
+    \frac{\phi(j)}{\phi(j-1)} = \frac{\lambda_{j-1}}{\lambda_j} \geq 1
+$$
+
+Therefore, for any $j\geq 1$, it must be:
+
+$$
+    \phi(j) \geq \phi(j-1)
+$$
+
+It follows that $\phi$ is non-decreasing on $\ZZ_+$.
+
+But $\dD$ contains no non-decreasing functions when the state space is infinite.
 (Why?)
 
 Contradiction.


### PR DESCRIPTION
Dear @jstac , thanks for the inspiring talk and really nice discussions with me.

As we discussed, for lecture [ergodicity](https://github.com/jstac/continuous_time_mcs/blob/master/ctmc_lectures/ergodicity.md#solution-to-exercise-2), this PR adds ``non-increasing`` condition on $(\lambda_k)$ 
- "Let $(\lambda_k)$ be a bounded sequence in $(0, \infty)$." -->> "Let $(\lambda_k)$ be a bounded non-increasing sequence in $(0, \infty)$." 

and corrects the solution to exercise 2 as:

"Suppose to the contrary that $\phi \in \dD$ and $\phi Q = 0$.

Then, for any $j \geq 1$,

$$ (\phi Q)(j) = \sum_{i \geq 0} \phi(i) Q(i, j) = - \lambda_j \phi(j) + \lambda_{j-1} \phi(j-1) = 0$$

Since $(\lambda_k)$ is non-increasing, it follows that

$$ \frac{\phi(j)}{\phi(j-1)} = \frac{\lambda_{j-1}}{\lambda_j} \geq 1 $$

Therefore, for any $j\geq 1$, it must be either one of two cases:

1. $\phi(j)= \phi(j-1)$ or
2. $\phi(j) \geq \phi(j-1)$.


For case $1$, it follows that $\phi$ is constant on $\ZZ_+$.

For case $2$, it follows that $\phi$ is increasing on $\ZZ_+$.

But $\dD$ contains no constant or increasing functions when the state space is infinite.
(Why?)

Contradiction."

Look forward to your comments.

This PR fixes #82 .