### PR TITLE
ENH: enable sphinx-exercise and migrate exercise text

### DIFF
--- a/ctmc_lectures/_config.yml
+++ b/ctmc_lectures/_config.yml
@@ -39,6 +39,7 @@ sphinx:
 
     extra_extensions:
         - sphinx_proof
+        - sphinx_exercise
 
 execute:
     execute_notebooks: cache

--- a/ctmc_lectures/ergodicity.md
+++ b/ctmc_lectures/ergodicity.md
@@ -626,14 +626,14 @@ A solved exercise below asks you to confirm this.
 
 ## Exercises
 
-### Exercise 1
-
+```{exercise}
+:label: ergodicity-ex-1
 Let $(P_t)$ be a Markov semigroup.  True or false:
-for this semigroup, every state $x$ is accessible from itself. 
+for this semigroup, every state $x$ is accessible from itself.
+```
 
-
-### Exercise 2
-
+```{exercise}
+:label: ergodicity-ex-2
 Let $(\lambda_k)$ be a bounded non-increasing sequence in $(0, \infty)$.
 
 A **pure birth process** starting at zero is a continuous time Markov process
@@ -650,20 +650,22 @@ $$
 
 Show that $(P_t)$, the corresponding Markov semigroup, has no stationary
 distribution.
+```
 
-### Exercise 3
 
+```{exercise}
+:label: ergodicity-ex-3
 Confirm that {prf:ref}`sdrift` implies {prf:ref}`sfinite`.
-
+```
 
 ## Solutions
 
-### Solution to Exercise 1
-
+```{solution} ergodicity-ex-1
 The statement is true.  With $t=0$ we have $P_t(x,x) = I(x,x) = 1 > 0$.
+```
 
-### Solution to Exercise 2
 
+```{solution} ergodicity-ex-2
 Suppose to the contrary that $\phi \in \dD$ and $\phi Q = 0$.
 
 Then, for any $j \geq 1$,
@@ -693,9 +695,10 @@ But $\dD$ contains no non-decreasing functions when the state space is infinite.
 (Why?)
 
 Contradiction.
+```
 
-### Solution to Exercise 3
 
+```{solution} ergodicity-ex-3
 Let $(P_t)$ be an irreducible UC Markov semigroup and let $S$ be finite.
 
 Pick any positive constants $M, \epsilon$ and set $v = M$ and $F = S$.
@@ -704,9 +707,10 @@ We then have
 
 $$
     \sum_y Q(x, y) v(y)
-    = M \sum_y Q(x, y) 
+    = M \sum_y Q(x, y)
     = 0
 $$
 
 Hence the drift condition in {prf:ref}`sdrift` holds and $(P_t)$ is
 asymptotically stable.
+```

--- a/ctmc_lectures/generators.md
+++ b/ctmc_lectures/generators.md
@@ -211,11 +211,13 @@ $$
 $h \to 0$ in {eq}`devlim` is the right limit.)
 
 ```{prf:example}
+:label: generators-prf-1
 If $U_t = t V$ for some fixed $V \in \linop$, then it is easy to
 see that $V$ is the derivative of $t \mapsto U_t$ at every $t \in \RR_+$.
 ```
 
 ```{prf:example}
+:label: generators-prf-2
 In {doc}`our discussion <kolmogorov_fwd>` of the Kolmogorov forward equation 
 when $S$ is finite, we introduced the derivative of a map $t
 \mapsto P_t$, where each $P_t$ is a matrix on $S$.

--- a/ctmc_lectures/generators.md
+++ b/ctmc_lectures/generators.md
@@ -424,14 +424,17 @@ example, Chapter 7 of {cite}`bobrowski2005functional`.
 
 ## Exercises
 
-### Exercise 1
+```{exercise}
+:label: generators-ex-1
 
 Prove that {eq}`expdiffer` holds for all $A \in \linop$.
+```
 
-### Exercise 2
+```{exercise}
+:label: generators-ex-2
 
 In many texts, a $C_0$ semigroup is defined as an evolution semigroup $(U_t)$
-such that 
+such that
 
 $$
     U_t g \to g \text{ as } t \to 0 \text{ for any } g \in \BB
@@ -442,16 +445,17 @@ in the definition we used above.
 
 The [Banach--Steinhaus Theorem](https://en.wikipedia.org/wiki/Uniform_boundedness_principle) can be used to show that, for an evolution semigroup $(U_t)$ satisfying {eq}`czsg2`, there exist finite constants $\omega$ and $M$ such that
 
-$$ 
-    \| U_t \| \leq e^{t\omega} M 
+$$
+    \| U_t \| \leq e^{t\omega} M
     \quad \text{for all } \; t \geq 0
 $$ (sgbound)
 
 Using this and {eq}`czsg2`, show that, for any $g \in \BB$, the map $t \mapsto
 U_t g$ is continuous at all $t$.
+```
 
-
-### Exercise 3
+```{exercise}
+:label: generators-ex-3
 
 Following on from the previous exercise, 
 a UC semigroup is often defined as an evolution semigroup $(U_t)$
@@ -466,12 +470,12 @@ in the definition we used above.
 
 In particular, show that, for any $t_n \to t$, we have
 $\| U_{t_n} - U_t \| \to 0$  as $n \to \infty$.
-
+```
 
 
 ## Solutions
 
-### Solution to Exercise 1
+```{solution} ergodicity-ex-1
 
 To show the first equality, fix $t \in \RR_+$, take $h > 0$ and observe that
 
@@ -487,9 +491,9 @@ Using the definition of the exponential, this is easily verified,
 completing the proof of the first equality in {eq}`expdiffer`.
 
 The proof of the second equality is similar.
+```
 
-
-### Solution to Exercise 2
+```{solution} ergodicity-ex-2
 
 Let $(U_t)$ be an evolution semigroup satisfying {eq}`czsg2` and let
 $\omega$ and $M$ be as in {eq}`sgbound`.
@@ -508,8 +512,9 @@ $$
 $$
 
 as $n \to \infty$.  This completes the proof.
+```
 
-### Solution to Exercise 3
+```{solution} ergodicity-ex-3
 
 The solution is similar to that of the previous exercise.
 
@@ -528,3 +533,4 @@ $$
 $$
 
 This converges to 0 as $n \to \infty$, completing our proof.
+```

--- a/ctmc_lectures/kolmogorov_bwd.md
+++ b/ctmc_lectures/kolmogorov_bwd.md
@@ -534,16 +534,15 @@ Try to supply a proof.
 
 ## Solutions
 
-````{solution} kolmogorov-bwd-1
-
-Here is one solution:
-
 ```{note}
 code is currently not supported in `sphinx-exercise`
 so code-cell solutions are immediately after this
 solution block.
 ```
-````
+
+```{solution} kolmogorov-bwd-1
+Here is one solution:
+```
 
 ```{code-cell} ipython3
 α = 0.6
@@ -587,7 +586,6 @@ ax.set_xlabel("inventory", fontsize=14)
 
 plt.show()
 ```
-
 
 
 ```{solution} kolmogorov-bwd-2

--- a/ctmc_lectures/kolmogorov_bwd.md
+++ b/ctmc_lectures/kolmogorov_bwd.md
@@ -14,7 +14,7 @@ kernelspec:
 
 # The Kolmogorov Backward Equation
 
-## Overview 
+## Overview
 
 As models become more complex, deriving analytical representations of the
 Markov semigroup $(P_t)$ becomes harder.
@@ -477,7 +477,7 @@ def independent_draws(T=10, num_draws=100):
 
 ```{code-cell} ipython3
 T = 30
-n = b + 1 
+n = b + 1
 draws = independent_draws(T, num_draws=100_000)
 fig, ax = plt.subplots()
 
@@ -495,13 +495,14 @@ mass on zero is due to the low arrival rate $\gamma$ for inventory.
 
 ## Exercises
 
-### Exercise 1
+````{exercise}
+:label: kolmogorov-bwd-1
 
 In the discussion above, we generated an approximation of $\psi_T$ when
 $T=30$, the initial condition is Binomial$(n, 0.25)$ and parameters
 are set to
 
-```{code-cell} ipython3
+```ipython3
 α = 0.6
 λ = 0.5
 γ = 0.1
@@ -512,12 +513,16 @@ The calculation was done by simulating independent draws and histogramming.
 
 Try to generate the same figure using {eq}`psolq` instead, modifying code from
 {ref}`our lecture <markov_prop>` on the Markov property.
+````
 
-### Exercise 2
+```{exercise}
+:label: kolmogorov-bwd-2
 
 Prove that differentiating {eq}`kbinteg` at each $(x, y)$ yields {eq}`kolbackeq`.
+```
 
-### Exercise 3
+```{exercise}
+:label: kolmogorov-bwd-3
 
 We claimed above that the solution $P_t = e^{t Q}$ is the unique
 Markov semigroup satisfying the backward equation $P'_t = Q P_t$.
@@ -525,15 +530,27 @@ Markov semigroup satisfying the backward equation $P'_t = Q P_t$.
 Try to supply a proof.
 
 (This is not an easy exercise but worth thinking about in any case.)
-
+```
 
 ## Solutions
 
-### Solution to Exercise 1
+````{solution} kolmogorov-bwd-1
 
 Here is one solution:
 
+```{note}
+code is currently not supported in `sphinx-exercise`
+so code-cell solutions are immediately after this
+solution block.
+```
+````
+
 ```{code-cell} ipython3
+α = 0.6
+λ = 0.5
+γ = 0.1
+b = 10
+
 states = np.arange(n)
 I = np.identity(n)
 
@@ -573,7 +590,7 @@ plt.show()
 
 
 
-### Solution to Exercise 2
+```{solution} kolmogorov-bwd-2
 
 One can easily verify that, when $f$ is a differentiable function and $\alpha >
 0$, we have
@@ -588,11 +605,11 @@ Note also that, with the change of variable $s = t - \tau$, we can rewrite
 {eq}`kbinteg` as
 
 $$
-    P_t(x, y) = 
-    e^{-t \lambda(x)} 
-    \left\{ 
+    P_t(x, y) =
+    e^{-t \lambda(x)}
+    \left\{
         I(x, y)
-        + \lambda(x) 
+        + \lambda(x)
         \int_0^t (K P_s)(x, y) e^{s \lambda(x)} d s
     \right\}
 $$ (kbinteg2)
@@ -600,11 +617,11 @@ $$ (kbinteg2)
 Applying {eq}`gdiff` yields
 
 $$
-    P'_t(x, y) 
-    = e^{-t \lambda(x)} 
+    P'_t(x, y)
+    = e^{-t \lambda(x)}
         \left\{ 
-             \lambda(x) 
-             (K P_t)(x, y) e^{t \lambda(x)} 
+             \lambda(x)
+             (K P_t)(x, y) e^{t \lambda(x)}
         \right\}
         - \lambda(x) P_t(x, y)
 $$
@@ -612,18 +629,19 @@ $$
 After minor rearrangements this becomes
 
 $$
-    P'_t(x, y) 
-    = \lambda(x) [ (K - I)  P_t](x, y) 
+    P'_t(x, y)
+    = \lambda(x) [ (K - I)  P_t](x, y)
 $$
 
 which is identical to {eq}`kolbackeq`.
+```
 
 
-### Solution to Exercise 3
+```{solution} kolmogorov-bwd-3
 
 Here is one proof of uniqueness.
 
-Suppose that $(\hat P_t)$ is another Markov semigroup satisfying 
+Suppose that $(\hat P_t)$ is another Markov semigroup satisfying
 $P'_t = Q P_t$.
 
 Fix $t > 0$ and let $V_s$ be defined by $V_s = P_s \hat P_{t-s}$ for all $s
@@ -647,5 +665,4 @@ Hence $V_s$ is constant, so our previous observations $V_0 = \hat P_t$ and $V_t 
 now yield $\hat P_t = P_t$.
 
 Since $t$ was arbitrary, the proof is now done.
-
-
+```

--- a/ctmc_lectures/kolmogorov_bwd.md
+++ b/ctmc_lectures/kolmogorov_bwd.md
@@ -512,7 +512,7 @@ b = 10
 The calculation was done by simulating independent draws and histogramming.
 
 Try to generate the same figure using {eq}`psolq` instead, modifying code from
-{ref}`our lecture <markov_prop>` on the Markov property.
+{doc}`our lecture <markov_prop>` on the Markov property.
 ````
 
 ```{exercise}

--- a/ctmc_lectures/kolmogorov_fwd.md
+++ b/ctmc_lectures/kolmogorov_fwd.md
@@ -390,7 +390,7 @@ are equivalent:
 1. $Q$ is an intensity matrix.
 ```
 
-The proof is related to that of {prf:ref}`jctosg` and is found as 
+The proof is related to that of {prf:ref}`jctosg` and is found as
 a solved exercise below.
 
 ```{prf:corollary}
@@ -436,8 +436,8 @@ Q$, which is the Fokker--Planck equation.
 More explicitly, for given $y \in S$,
 
 $$
-    \psi_t'(y) 
-    = \sum_{x \not= y} \psi_t(x) \lambda(x) K(x, y) - \psi_t(y) \lambda(y) 
+    \psi_t'(y)
+    = \sum_{x \not= y} \psi_t(x) \lambda(x) K(x, y) - \psi_t(y) \lambda(y)
 $$
 
 The rate of probability flow into $y$ is equal to the inflow from other states
@@ -449,7 +449,7 @@ minus the outflow.
 
 We have seen that any intensity matrix $Q$ on $S$ defines a Markov semigroup via $P_t = e^{tQ}$.
 
-Henceforth, we will say that $(X_t)$ is **a Markov chain with intensity matrix** $Q$ if 
+Henceforth, we will say that $(X_t)$ is **a Markov chain with intensity matrix** $Q$ if
 $(X_t)$ is a Markov chain with Markov semigroup $(e^{tQ})$.
 
 While our discussion has been in the context of a finite state space, later we
@@ -462,7 +462,7 @@ is a Markov chain with intensity matrix $Q$ for some suitably chosen $Q$.
 Later we will prove this to be universally true when $S$ is finite and true
 under mild conditions when $S$ is countably infinite.
 
-Intensity matrices are important because 
+Intensity matrices are important because
 
 1. they are the natural infinitesimal descriptions of Markov semigroups,
 2. they are often easy to write down in applications and
@@ -480,7 +480,8 @@ Later, we will see that, for a given intensity matrix $Q$, the elements are
 
 ## Exercises
 
-### Exercise 1
+```{exercise}
+:label: kolmogorov-fwd-1
 
 Let $(P_t)$ be a Markov semigroup such that $t \mapsto P_t(x, y)$ is
 differentiable at all $t \geq 0$ and $(x, y) \in S \times S$.
@@ -489,7 +490,7 @@ differentiable at all $t \geq 0$ and $(x, y) \in S \times S$.
 
 Define (pointwise, at each $(x,y)$),
 
-$$ 
+$$
     Q := P'_0 = \lim_{h \downarrow 0} \frac{P_h - I}{h}
 $$ (genfl)
 
@@ -498,13 +499,14 @@ Assuming that this limit exists, and hence $Q$ is well-defined, show that
 $$
     P'_t = P_t Q
     \quad \text{and} \quad
-    P'_t = Q P_t 
+    P'_t = Q P_t
 $$
 
 both hold. (These are the Kolmogorov forward and backward equations.)
+```
 
-
-### Exercise 2
+```{exercise}
+:label: kolmogorov-fwd-2
 
 Recall {ref}`our model <sdji>` of jump chains with state-dependent jump
 intensities given by rate function $x \mapsto \lambda(x)$.
@@ -513,56 +515,58 @@ After a wait time with exponential rate $\lambda(x) \in (0, \infty)$, the
 state transitions from $x$ to $y$ with probability $K(x,y)$.
 
 We found that the associated semigroup $(P_t)$ satisfies the Kolmogorov
-backward equation $P'_t = Q P_t$ with 
+backward equation $P'_t = Q P_t$ with
 
 $$
     Q(x, y) := \lambda(x) (K(x, y) - I(x, y))
 $$ (qeqagain)
 
 Show that $Q$ is an intensity matrix and that {eq}`genfl` holds.
+```
 
-### Exercise 3 
+```{exercise}
+:label: kolmogorov-fwd-3
 
 Prove {prf:ref}`intvsmk` by adapting the arguments in {prf:ref}`jctosg`.
 (This is nontrivial but worth at least trying.)
 
 Hint: The constant $m$ in the proof can be set to $\max_x |Q(x, x)|$.
-
+```
 
 
 ## Solutions
 
-### Solution to Exercise 1
+```{solution} kolmogorov-fwd-1
 
 Let $(P_t)$ be a Markov semigroup and let $Q$ be as defined in the statement
 of the exercise.
 
-Fix $t \geq 0$ and $h > 0$. 
+Fix $t \geq 0$ and $h > 0$.
 
 Combining the semigroup property and linearity with the restriction $P_0 = I$, we get
 
 $$
-    \frac{P_{t+h} - P_t}{h}  
-    = \frac{P_t P_h - P_t}{h}  
-    = \frac{P_t (P_h - I)}{h}  
+    \frac{P_{t+h} - P_t}{h}
+    = \frac{P_t P_h - P_t}{h}
+    = \frac{P_t (P_h - I)}{h}
 $$
 
 Taking $h \downarrow 0$ and using the definition of $Q$ give $P_t' = P_t Q$,
 which is the Kolmogorov forward equation.
 
-For the backward equation we observe that 
+For the backward equation we observe that
 
 $$
-    \frac{P_{t+h} - P_t}{h}  
-    = \frac{P_h P_t - P_t}{h}  
-    = \frac{(P_h - I) P_t}{h}  
+    \frac{P_{t+h} - P_t}{h}
+    = \frac{P_h P_t - P_t}{h}
+    = \frac{(P_h - I) P_t}{h}
 $$
 
 also holds.  Taking $h \downarrow 0$ gives the Kolmogorov backward equation.
+```
 
 
-
-### Solution to Exercise 2
+```{solution} kolmogorov-fwd-2
 
 Let $Q$ be as defined in {eq}`qeqagain`.
 
@@ -575,14 +579,15 @@ For the second, we use the fact that $K$ is a Markov matrix, so that, with $1$
 as a column vector of ones,
 
 $$
-    Q 1 
+    Q 1
     = \lambda (K 1 - 1)
     = \lambda (1 - 1)
     = 0
 $$
+```
 
-### Solution to Exercise 3
 
+```{solution} kolmogorov-fwd-3
 
 Suppose that $Q$ is an intensity matrix, fix $t \geq 0$ and set $P_t = e^{tQ}$.
 
@@ -603,7 +608,7 @@ We conclude that $P_t$ is a Markov matrix.
 Regarding the converse implication, suppose that $P_t = e^{tQ}$ is a Markov
 matrix for all $t$ and let $1$ be a column vector of ones.
 
-Because $P_t$ has unit row sums and differentiation is linear, 
+Because $P_t$ has unit row sums and differentiation is linear,
 we can employ the Kolmogorov backward equation to obtain
 
 $$
@@ -629,5 +634,4 @@ $t$, we see that the off diagonal elements of $Q$ must be
 nonnegative.
 
 Hence $Q$ is an intensity matrix.
-
-
+```

--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -949,6 +949,12 @@ The initial condition is ``ψ_0 = binom.pmf(states, n, 0.25)`` where ``n = b + 1
 
 ## Solutions
 
+```{note}
+code is currently not supported in `sphinx-exercise`
+so code-cell solutions are immediately after this
+solution block.
+```
+
 ```{solution} markov-prop-1
 
 This is easy.
@@ -1039,18 +1045,12 @@ The last expression equals $\mathbf P_\psi^n$, which concludes the proof.
 ```
 
 
-````{solution} markov-prop-4
+```{solution} markov-prop-4
 Here is one approach.
 
 (The statements involving ``glue`` are specific to this book and can be deleted
 by most readers.  They store the output so it can be displayed elsewhere.)
-
-```{note}
-code is currently not supported in `sphinx-exercise`
-so code-cell solutions are immediately after this
-solution block.
 ```
-````
 
 ```{code-cell} ipython3
 α = 0.6

--- a/ctmc_lectures/markov_prop.md
+++ b/ctmc_lectures/markov_prop.md
@@ -897,16 +897,18 @@ In the (solved) exercises you will be asked to try to reproduce this figure.
 
 ## Exercises
 
-### Exercise 1
+```{exercise}
+:label: markov-prop-1
 
 Consider the binary (Bernoulli) distribution where outcomes $0$ and $1$ each have
 probability $0.5$.
 
 Construct two different random variables with this distribution.
+```
 
 
-
-### Exercise 2
+```{exercise}
+:label: markov-prop-2
 
 Show by direct calculation that the Poisson matrices $(P_t)$ defined in 
 {eq}`poissemi` satisfy the semigroup property {eq}`chapkol_ct2`.
@@ -915,9 +917,11 @@ Hints
 
 * Recall that $P_t(j, k) = 0$ whenever $j > k$.
 * Consider using the [binomial formula](https://en.wikipedia.org/wiki/Binomial_theorem).
+```
 
 
-### Exercise 3
+```{exercise}
+:label: markov-prop-3
 
 Consider the distribution over $S^{n+1}$ previously shown in {eq}`mathjointd`, which is
 
@@ -932,17 +936,20 @@ $$
 Show that, for any Markov chain $(X_t)$ satisfying {eq}`markovpropd`
 and $X_0 \sim \psi$, the restriction $(X_0, \ldots, X_n)$ has joint
 distribution $\mathbf P_\psi^n$.
+```
 
-### Exercise 4
+
+```{exercise}
+:label: markov-prop-4
 
 Try to produce your own version of the figure {ref}`flow_fig`
 
 The initial condition is ``ψ_0 = binom.pmf(states, n, 0.25)`` where ``n = b + 1``.
-
+```
 
 ## Solutions
 
-### Solution to Exercise 1
+```{solution} markov-prop-1
 
 This is easy.
 
@@ -953,10 +960,10 @@ Then $X$ has the desired distribution.
 
 Alternatively, we could take $Z$ to be standard normal and set $X=0$ if $Z <
 0$ and $1$ otherwise.
- 
+```
 
-### Solution to Exercise 2
 
+```{solution} markov-prop-2
 Fixing $s, t \in \RR_+$ and $j \leq k$, we have 
 
 $$
@@ -993,10 +1000,10 @@ $$
 $$
 
 Hence {eq}`chapkol_ct2` holds, and the semigroup property is satisfied.
+```
 
 
-### Solution to Exercise 3 
-
+```{solution} markov-prop-3
 Let $(X_t)$ be a Markov chain satisfying {eq}`markovpropd` and $X_0 \sim \psi$.
 
 When $n=0$, we have $\mathbf P_\psi^n = \mathbf P_\psi^0 = \psi$, and this
@@ -1029,14 +1036,21 @@ $$
 $$
 
 The last expression equals $\mathbf P_\psi^n$, which concludes the proof.
+```
 
 
-### Solution to Exercise 4 
-
+````{solution} markov-prop-4
 Here is one approach.
 
 (The statements involving ``glue`` are specific to this book and can be deleted
 by most readers.  They store the output so it can be displayed elsewhere.)
+
+```{note}
+code is currently not supported in `sphinx-exercise`
+so code-cell solutions are immediately after this
+solution block.
+```
+````
 
 ```{code-cell} ipython3
 α = 0.6

--- a/ctmc_lectures/memoryless.md
+++ b/ctmc_lectures/memoryless.md
@@ -389,7 +389,8 @@ This connects to Poisson process theory, as we shall soon see.
 
 ## Exercises
 
-### Exercise 1
+```{exercise}
+:label: memoryless-ex-1
 
 Due to its memoryless property, we can "stop" and "restart" an exponential
 draw without changing its distribution.
@@ -404,9 +405,10 @@ In particular, consider the random variable $X$ defined as follows:
 * If not, draw $Z$ independently from $\Exp(\lambda)$ and set $X = s + Z$.
 
 Show that $X \sim \Exp(\lambda)$.
+```
 
-
-### Exercise 2
+```{exercise}
+:label: memoryless-ex-2
 
 Fix $\lambda = 0.5$ and $s=1.0$.
 
@@ -418,12 +420,12 @@ and compare to $t \mapsto e^{-\lambda t}$.
 Is the fit good?  How about if the number of draws is increased?
 
 Are the results in line with those of the previous exercise?
-
+```
 
 ## Solutions
 
 
-### Solution to Exercise 1
+```{solution} memoryless-ex-1
 
 Let $X$ be constructed as in the statement of the exercise and fix $t > 0$.
 
@@ -446,11 +448,18 @@ $$
 $$
 
 Either way, we have $X \sim \Exp(\lambda)$, as was to be shown.
+```
 
 
-### Solution to Exercise 2
-
+````{solution} memoryless-ex-2
 Here's one solution, starting with 1,000 draws.
+
+```{note}
+code is currently not supported in `sphinx-exercise`
+so code-cell solutions are immediately after this
+solution block.
+```
+````
 
 ```{code-cell} ipython3
 
@@ -479,12 +488,15 @@ ax.plot(t_grid, empirical_exceedance, label='empirical exceedance')
 ax.legend()
 
 plt.show()
-
 ```
+
+```{solution} memoryless-ex-2
+**Solution Continued:**
 
 The fit is already very close, which matches with the theory in Exercise 1.
 
 The two lines become indistinguishable as $n$ is increased further.
+```
 
 ```{code-cell} ipython3
 
@@ -496,7 +508,6 @@ ax.plot(t_grid, empirical_exceedance, label='empirical exceedance')
 ax.legend()
 
 plt.show()
-
 ```
 
 

--- a/ctmc_lectures/memoryless.md
+++ b/ctmc_lectures/memoryless.md
@@ -424,6 +424,11 @@ Are the results in line with those of the previous exercise?
 
 ## Solutions
 
+```{note}
+code is currently not supported in `sphinx-exercise`
+so code-cell solutions are immediately after this
+solution block.
+```
 
 ```{solution} memoryless-ex-1
 
@@ -451,18 +456,11 @@ Either way, we have $X \sim \Exp(\lambda)$, as was to be shown.
 ```
 
 
-````{solution} memoryless-ex-2
+```{solution} memoryless-ex-2
 Here's one solution, starting with 1,000 draws.
-
-```{note}
-code is currently not supported in `sphinx-exercise`
-so code-cell solutions are immediately after this
-solution block.
 ```
-````
 
 ```{code-cell} ipython3
-
 λ = 0.5 
 np.random.seed(1234)
 t_grid = np.linspace(0, 10, 200)

--- a/ctmc_lectures/poisson.md
+++ b/ctmc_lectures/poisson.md
@@ -409,8 +409,8 @@ Poisson process independent of $(N_r)_{r \leq s}$.
 
 ## Exercises
 
-Exercise 1
-----------
+```{exercise}
+:label: poisson-ex-1
 
 Fix $\lambda > 0$ and draw $\{W_i\}$ as IID exponentials with rate $\lambda$.
 
@@ -425,29 +425,34 @@ comparing the empirical distribution of the sample with a Poisson
 distribution with rate $T \lambda$.
 
 Try first with $\lambda = 0.5$ and $T=10$.
+```
 
-Exercise 2
-----------
 
+```{exercise}
+:label: poisson-ex-2
 
 In the lecture we used the fact that $\Binomial(n, \theta) \approx \Poisson(n \theta)$ when $n$ is large and $\theta$ is small.
 
 Investigate this relationship by plotting the distributions side by side.
 
 Experiment with different values of $n$ and $\theta$.
-
+```
 
 ## Solutions
 
+```{note}
+code is currently not supported in `sphinx-exercise`
+so code-cell solutions are immediately after this
+solution block.
+```
 
-### Solution to Exercise 1
-
-Here is one solution.  
+```{solution} poisson-ex-1
+Here is one solution.
 
 The figure shows that the fit is already good with a modest sample size.
 
 Increasing the sample size will further improve the fit.
-
+```
 
 ```{code-cell} ipython3
 λ = 0.5
@@ -483,9 +488,9 @@ vals = np.arange(0, max_val+1)
 
 fig, ax = plt.subplots()
 
-ax.plot(vals, [poisson(v, T * λ) for v in vals], 
+ax.plot(vals, [poisson(v, T * λ) for v in vals],
     marker='o', label='poisson')
-ax.plot(vals, [np.mean(sample==v) for v in vals], 
+ax.plot(vals, [np.mean(sample==v) for v in vals],
     marker='o', label='empirical')
 
 ax.legend(fontsize=12)
@@ -493,10 +498,10 @@ plt.show()
 ```
 
 
-### Solution to Exercise 2
-
+```{solution} poisson-ex-2
 Here is one solution.  It shows that the approximation is good when $n$ is
 large and $\theta$ is small.
+```
 
 ```{code-cell} ipython3
 def binomial(k, n, p):

--- a/ctmc_lectures/uc_mc_semigroups.md
+++ b/ctmc_lectures/uc_mc_semigroups.md
@@ -498,44 +498,49 @@ For more discussion, see, for example, Section 2.7 of {cite}`norris1998markov`.
 
 ## Exercises
 
-### Exercise 1
+```{exercise}
+:label: uc-mc-semigroups-ex-1
 
 Let $P$ be a Markov matrix on $S$ and identify it with the linear operator in
 {eq}`mmismo`.  Verify the claims in {eq}`propp`.
+```
 
-### Exercise 2
+```{exercise}
+:label: uc-mc-semigroups-ex-2
 
 Prove the claim in {prf:ref}`scintcon`.
+```
 
-### Exercise 3
+```{exercise}
+:label: uc-mc-semigroups-ex-3
 
 Confirm that $Q$ defined in {eq}`poissonq` induces a bounded linear operator on
 $\ell_1$ via {eq}`imislo`.
+```
 
-
-### Exercise 4
+```{exercise}
+:label: uc-mc-semigroups-ex-4
 
 Let $K$ be defined on $\ZZ_+ \times \ZZ_+$ by $K(i, j) = \mathbb 1\{j = i + 1\}$. 
 
 Show that, with $K^m$ representing the $m$-th matrix product of $K$ with itself, 
 we have $K^m(i, j) = \mathbb 1\{j = i + m\}$ for any $i, j \in \ZZ_+$.
-    
-### Exercise 5
+```
+
+```{exercise}
+:label: uc-mc-semigroups-ex-5
 
 Let $Q$ be any intensity matrix on $S$.
 
 Prove that the jump chain decomposition of $Q$ is in fact a jump chain pair.
 
 Prove that, in addition, this decomposition $(\lambda, K)$ satisfies {eq}`jcinmat`.
-
-
-
+```
 
 
 ## Solutions
 
-### Solution to Exercise 1
-
+```{solution} uc-mc-semigroups-ex-1
 To determine the norm of $P$, we use the definition in {eq}`norml`.
 
 If $f \in \ell_1$ and $\| f \| \leq 1$, then 
@@ -565,10 +570,10 @@ $$
 $$
 
 Hence $\phi P \in \dD$ as claimed.
+```
 
-### Solution to Exercise 2
 
-
+```{solution} uc-mc-semigroups-ex-2
 Here is one solution.
 
 Let $Q$ be an intensity matrix on $S$.
@@ -605,8 +610,10 @@ $$
 $$
 
 Contradiction.
+```
 
-### Solution to Exercise 3
+
+```{solution} uc-mc-semigroups-ex-3
 
 Linearity is obvious so we focus on boundedness.
 
@@ -623,10 +630,10 @@ by $2 \lambda \| f\|$.
 
 Hence $\| fQ \| \leq 2 \lambda \|f\|$, which implies that $Q \in \lL(\ell_1)$
 as required.
+```
 
 
-
-### Solution to Exercise 4
+```{solution} uc-mc-semigroups-ex-4
 
 The statement $K^m(i, j) = \mathbb 1\{j = i + m\}$ holds by definition when
 $m=1$.
@@ -643,9 +650,10 @@ $$
 $$
 
 Applying the definition $K(i, j) = \mathbb 1\{j = i + 1\}$ completes verification of the claim.
+```
 
 
-### Solution to Exercise 5
+```{solution} uc-mc-semigroups-ex-5
 
 Let $Q$ be an intensity matrix and let $(\lambda, K)$ be the jump chain
 decomposition of $Q$.
@@ -677,4 +685,4 @@ the details are omitted.
 
 (Try working case-by-case, with $\lambda(x) = 0, x=y$, $\lambda(x) > 0, x=y$, etc.)
 
-
+```

--- a/ctmc_lectures/uc_mc_semigroups.md
+++ b/ctmc_lectures/uc_mc_semigroups.md
@@ -153,6 +153,7 @@ The second last of these results is the Kolmogorov forward and backward equation
 The last of these results shows that we can obtain the intensity matrix $Q$ by differentiating $P_t$ at $t=0$.
 
 ```{prf:example}
+:label: uc-mc-semigroups-prf-1
 Let us consider again the Poisson process $(N_t)$ with rate $\lambda > 0$ 
 in light of the discussion above.
 


### PR DESCRIPTION
This PR enables `sphinx-exercise` and migrates to use the directives `exercise` and `solution`:

**HTML:**

![Screen Shot 2021-10-20 at 9 49 37 am](https://user-images.githubusercontent.com/8263752/138001221-306744c8-5c2d-421b-a3a5-25e9f17c2953.png)

**LaTeX:** 

<img width="829" alt="Screen Shot 2021-10-20 at 11 08 06 am" src="https://user-images.githubusercontent.com/8263752/138006834-74b8e11a-0edc-4f1a-ab81-3e8ed000d1c9.png">

