### PR TITLE
MAINT: upgrade sphinx-tojupyter==0.4.0 (glue support)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book==1.0.4post1
     - quantecon-book-theme==0.8.3
-    - sphinx-tojupyter==0.3.1
+    - sphinx-tojupyter==0.4.0
     - sphinx-proof==0.2.1
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.0.1


### PR DESCRIPTION
This PR upgrades `sphinx-tojupyter==0.4.0` for `glue` support in download notebooks and collab notebooks. 