### PR TITLE
Upgrade sphinx-tojupyter to 0.6.0

### DIFF
--- a/_notebook_repo/environment.yml
+++ b/_notebook_repo/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book==0.15.1
     - quantecon-book-theme==0.7.2
-    - git+https://github.com/QuantEcon/sphinx-tojupyter.git@add-sphinx-proof-support
+    - sphinx-tojupyter==0.6.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.4.1
     - ghp-import==2.1.0

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book==1.0.4post1
     - quantecon-book-theme==0.10.0
-    - git+https://github.com/QuantEcon/sphinx-tojupyter.git@add-sphinx-proof-support
+    - sphinx-tojupyter==0.6.0
     - sphinx-proof==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.2.1


### PR DESCRIPTION
This PR upgrades `sphinx-tojupyter` from 0.5.0 to 0.6.0, which adds support for sphinx-proof directives.

## Changes
- Upgraded `sphinx-tojupyter` from `0.5.0` to `0.6.0` in `environment.yml`
- Upgraded `sphinx-tojupyter` from `0.3.0` to `0.6.0` in `_notebook_repo/environment.yml`

## What's New in sphinx-tojupyter 0.6.0
- Added support for sphinx-proof directives (proof, theorem, axiom, lemma, definition, etc.)
- Improved conversion of proof-based content to Jupyter notebooks

Related: QuantEcon/sphinx-tojupyter#61

## Testing
CI will verify that the upgrade works correctly by building:
- PDF via LaTeX
- Jupyter notebooks via sphinx-tojupyter
- HTML website