### PR TITLE
⬆️ Configure dependabot for conda and ignore Python version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,4 @@ updates:
         versions: [">=2.0"]
       - dependency-name: "python"
         # Python version should be constrained by the anaconda distribution version
+        versions: [">0"]


### PR DESCRIPTION
Python version should be constrained by the anaconda distribution version specified in environment.yml, not updated independently by dependabot.

This also adds conda ecosystem monitoring to dependabot configuration.