### PR TITLE
INFR: Migrate GitHub Pages deploy to artifact-based workflow

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,4 +1,4 @@
-name: Link Checker [Anaconda, Linux]
+name: Link Checker
 on:
   schedule:
     # UTC 23:00 is early morning in Australia (9am)

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -11,19 +11,41 @@ jobs:
     permissions:
       issues: write # required for peter-evans/create-issue-from-file
     steps:
-      # Checkout the live site (html)
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          ref: gh-pages
+      # This repo deploys GitHub Pages via the artifact workflow (OIDC), so
+      # there is no gh-pages branch to check out — mirror the live site instead.
+      - name: Mirror published site
+        id: mirror
+        run: |
+          wget --quiet --recursive --no-parent --no-host-directories \
+               --accept html https://continuous-time-mcs.quantecon.org/ || true
+          count=$(find . -name '*.html' | wc -l | tr -d ' ')
+          echo "Mirrored $count HTML file(s) from https://continuous-time-mcs.quantecon.org/"
+          if [ "$count" -eq 0 ]; then
+            # Mirror failed (site down or wget broke). Don't run lychee against
+            # an empty mirror and report green — surface the failure instead.
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            mkdir -p lychee
+            {
+              echo "## Link Checker — mirror failed"
+              echo
+              echo "\`wget\` mirrored **0 HTML files** from https://continuous-time-mcs.quantecon.org/, so the link check did not run."
+              echo "The live site may be down, or the mirror step may be broken — please investigate."
+            } > lychee/out.md
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Link Checker
         id: lychee
+        if: steps.mirror.outputs.ok == 'true'
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
-          args: --accept 200,403,503 *.html
+          args: --accept 403,503 '**/*.html'
+
+      # Open an issue if the mirror failed, or if lychee found broken links.
       - name: Create Issue From File
-        if: steps.lychee.outputs.exit_code != 0
+        if: steps.mirror.outputs.ok != 'true' || steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Build & Publish to GH-PAGES
+name: Build & Publish to GH Pages
 on:
   push:
     tags:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,25 @@ on:
   push:
     tags:
       - 'publish*'
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write   # write: upload release assets (html archive, checksum, manifest)
+  pages: write
+  id-token: write   # required for OIDC-based Pages deployment
+
+# Allow only one concurrent deployment; don't cancel an in-flight deploy
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page-url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -74,12 +89,15 @@ jobs:
         shell: bash -l {0}
         run: |
           jb build lectures --path-output ./
-      - name: Deploy website to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: quantecon/actions/publish-gh-pages@v0.6.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/html/
+          build-dir: _build/html
           cname: continuous-time-mcs.quantecon.org
+          create-release-assets: 'true'
+          asset-name: 'continuous-time-mcs-html'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare continuous-time-mcs.notebooks sync
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
## What

Migrates GitHub Pages deployment from the legacy `gh-pages` branch method (`peaceiris/actions-gh-pages`) to the native, artifact-based deployment used across the family. This mirrors the reference implementation in [lecture-dp](https://github.com/QuantEcon/lecture-dp), which already runs on this pattern. See QuantEcon/meta#282 for the overall strategy and rationale.

## Why

The `gh-pages` branch accumulates a full HTML snapshot on every publish, bloating the repo and slowing clones over time. Artifact-based deployment stores nothing in git — the deployed site lives in the Pages infrastructure — so the repo stays small and the `gh-pages` branch can be deleted entirely.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/publish.yml` | Add `pages`/`id-token` permissions and a `pages` concurrency group; run the `publish` job in the `github-pages` environment; replace the `peaceiris/actions-gh-pages@v4` step with `quantecon/actions/publish-gh-pages@v0.6.0` (handles the CNAME and creates release assets). The bespoke build — LaTeX PDF, download-notebook build, and the sync to `continuous_time_mcs.notebooks` — is unchanged. |
| `.github/workflows/linkcheck.yml` | Stop checking out the `gh-pages` branch. Mirror the live site with `wget` (with a guard that surfaces a failure instead of reporting green on an empty mirror), so link checking no longer depends on the branch. |

## Required maintainer steps (settings — not in this PR)

The workflow change alone does not deploy. A repo admin must do the following, in order. Steps 2–3 must happen **before** the first tagged deploy or it will fail with *"Tag is not allowed to deploy to github-pages due to environment protection rules."*

1. Merge this PR.
2. **Settings → Pages → Source** → change to **"GitHub Actions"**.
3. **Settings → Environments → github-pages** → add a deployment rule of type **Tag** (not Branch) with the pattern `publish*`.
4. Push a `publish-*` tag to trigger a deploy, then verify: the site loads at https://continuous-time-mcs.quantecon.org/, and `gh api repos/QuantEcon/continuous_time_mcs/pages --jq '.build_type'` returns `workflow`.
5. Run the **Link Checker** workflow manually (`workflow_dispatch`) and confirm it mirrors the live site correctly.
6. Once the deploy is verified, delete the now-unused branch to reclaim space:

```bash
git push origin --delete gh-pages
```

## Rollback

If anything goes wrong before `gh-pages` is deleted: set **Settings → Pages → Source** back to "Deploy from a branch" → `gh-pages`, and the previous site serves again immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
