### PR TITLE
Fix linkcheck false positives from the gh-pages migration

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -9,27 +9,37 @@ jobs:
     name: Link Checking
     runs-on: "ubuntu-latest"
     permissions:
-      issues: write # required for peter-evans/create-issue-from-file
+      contents: read  # read the latest release asset
+      issues: write   # required for peter-evans/create-issue-from-file
     steps:
-      # This repo deploys GitHub Pages via the artifact workflow (OIDC), so
-      # there is no gh-pages branch to check out — mirror the live site instead.
-      - name: Mirror published site
-        id: mirror
+      # This repo deploys GitHub Pages via the artifact workflow (no gh-pages
+      # branch). Check links against the published HTML release asset — a
+      # permanent tarball of the full site (HTML plus _static/_images/_pdf/
+      # _notebooks) — so lychee resolves local asset and root-relative links
+      # without depending on the live site being reachable.
+      - name: Download and extract latest release HTML
+        id: fetch
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          wget --quiet --recursive --no-parent --no-host-directories \
-               --accept html https://continuous-time-mcs.quantecon.org/ || true
-          count=$(find . -name '*.html' | wc -l | tr -d ' ')
-          echo "Mirrored $count HTML file(s) from https://continuous-time-mcs.quantecon.org/"
+          asset_url=$(gh api repos/${{ github.repository }}/releases/latest \
+            --jq '.assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url' | head -1)
+          mkdir -p _site
+          if [ -n "$asset_url" ]; then
+            curl -sSL "$asset_url" | tar -xz -C _site || true
+          fi
+          count=$(find _site -name '*.html' | wc -l | tr -d ' ')
+          echo "Extracted $count HTML file(s) from the latest release asset"
           if [ "$count" -eq 0 ]; then
-            # Mirror failed (site down or wget broke). Don't run lychee against
-            # an empty mirror and report green — surface the failure instead.
+            # No usable release asset — don't run lychee against an empty tree
+            # and report green; surface the failure instead.
             echo "ok=false" >> "$GITHUB_OUTPUT"
             mkdir -p lychee
             {
-              echo "## Link Checker — mirror failed"
+              echo "## Link Checker — release asset missing"
               echo
-              echo "\`wget\` mirrored **0 HTML files** from https://continuous-time-mcs.quantecon.org/, so the link check did not run."
-              echo "The live site may be down, or the mirror step may be broken — please investigate."
+              echo "Could not download or extract an HTML \`.tar.gz\` from the latest release, so the link check did not run."
+              echo "Check that the most recent \`publish-*\` release has the \`continuous-time-mcs-html-*.tar.gz\` asset attached."
             } > lychee/out.md
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"
@@ -37,15 +47,18 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        if: steps.mirror.outputs.ok == 'true'
+        if: steps.fetch.outputs.ok == 'true'
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
-          args: --accept 403,503 '**/*.html'
+          # 200 must stay in --accept or every working link is flagged as an
+          # error. --root-dir resolves root-relative links (e.g.
+          # /_notebooks/*.ipynb, /_pdf/book.pdf) against the extracted site root.
+          args: --accept 200,403,503 --root-dir ${{ github.workspace }}/_site '_site/**/*.html'
 
-      # Open an issue if the mirror failed, or if lychee found broken links.
+      # Open an issue if the release asset was missing, or lychee found broken links.
       - name: Create Issue From File
-        if: steps.mirror.outputs.ok != 'true' || steps.lychee.outputs.exit_code != 0
+        if: steps.fetch.outputs.ok != 'true' || steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -22,8 +22,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # `|| true` + 2>/dev/null: a transient gh api error (rate-limit/auth)
+          # must not abort the step under `set -eo pipefail` — fall through to
+          # the empty-input guard below so it reports "release asset missing".
           asset_url=$(gh api repos/${{ github.repository }}/releases/latest \
-            --jq '.assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url' | head -1)
+            --jq '.assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url' 2>/dev/null | head -1 || true)
           mkdir -p _site
           if [ -n "$asset_url" ]; then
             curl -sSL "$asset_url" | tar -xz -C _site || true

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -51,10 +51,13 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
+          # Check only the top-level lecture pages (as the old checkout did) —
+          # not theme partials under _static/ (e.g. webpack-macros.html holds
+          # raw Jinja `{{ pathto(...) }}` that isn't a real link).
           # 200 must stay in --accept or every working link is flagged as an
           # error. --root-dir resolves root-relative links (e.g.
           # /_notebooks/*.ipynb, /_pdf/book.pdf) against the extracted site root.
-          args: --accept 200,403,503 --root-dir ${{ github.workspace }}/_site '_site/**/*.html'
+          args: --accept 200,403,503 --root-dir ${{ github.workspace }}/_site '_site/*.html'
 
       # Open an issue if the release asset was missing, or lychee found broken links.
       - name: Create Issue From File


### PR DESCRIPTION
## What

Fixes the noisy link-check reports (e.g. #214) introduced by the gh-pages migration (#213). Follow-up to that PR.

## The regression

Migration PR #213 switched the link checker from *checking out the `gh-pages` branch* to a `wget` mirror of the live site. Two problems came from that:

1. **`wget --accept html` fetches only HTML** — none of the `_static/*` CSS/JS, `_images/*`, `_pdf/`, or `_notebooks/` assets. lychee then checked those relative links as **local files** and reported them all as "Cannot find file". (The old gh-pages checkout had the whole site, assets included, so they resolved.)
2. **`--accept 403,503` dropped `200`** — so every *working* link, including the site's own pages, was flagged as "Rejected status code: 200".

Net effect in #214: **522 "errors" out of 1000**, essentially all false positives — **0 real broken links, 0 timeouts**. For comparison, the last pre-migration run (#212) reported 37 errors out of 1109.

| Error category in #214 | Count | Real? |
|---|--:|---|
| "Cannot find file" (assets not mirrored) | 190 | ❌ |
| "Rejected status code: 200" (accept list) | 171 | ❌ |
| "Error building URL" (root-relative links) | 20 | ❌ |

## The fix

Check links against the **published HTML release asset** — a permanent `.tar.gz` of the full site (HTML **plus** all assets) that the publish workflow now attaches to each `publish-*` release. This is the approach recommended in QuantEcon/meta#282 (lesson 2) and already used by `lecture-python-programming`.

- Download + extract `continuous-time-mcs-html-*.tar.gz` from the latest release into `_site` (replaces the `wget` mirror). No dependency on the live site being reachable at check time.
- Restore **`--accept 200,403,503`** so working links pass.
- Add **`--root-dir`** so root-relative links (`/_notebooks/*.ipynb`, `/_pdf/book.pdf`) resolve against the extracted site root.
- Keep the empty-input guard (now "release asset missing") and the `peter-evans/create-issue-from-file` reporting.

After this, a run should surface only genuine link issues (on the order of #212's ~37), not the ~485 false positives.

## Related

- Supersedes the false-alarm report in #214 (safe to close).
- `lecture-dp` uses the same `wget`-mirror linkcheck pattern and has the same latent issue — worth the same fix in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
