### PR TITLE
Harden linkcheck release-asset extract against partial downloads

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -29,7 +29,14 @@ jobs:
             --jq '.assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url' 2>/dev/null | head -1 || true)
           mkdir -p _site
           if [ -n "$asset_url" ]; then
-            curl -sSL "$asset_url" | tar -xz -C _site || true
+            # `curl -f` fails on HTTP errors; an `if !` guard catches a failed
+            # or partial download/extract and discards the incomplete tree, so
+            # lychee never runs against a half-extracted site (which would
+            # reintroduce "file not found" false positives).
+            if ! curl -fsSL "$asset_url" | tar -xz -C _site; then
+              echo "::warning::could not download/extract $asset_url — treating as no usable asset"
+              rm -rf _site && mkdir -p _site
+            fi
           fi
           count=$(find _site -name '*.html' | wc -l | tr -d ' ')
           echo "Extracted $count HTML file(s) from the latest release asset"


### PR DESCRIPTION
Ports the hardening from QuantEcon/lecture-dp#39 (a Copilot-review follow-up) to keep the two repos' link-check workflows in sync.

## Why

The fetch step ran `curl -sSL "$asset_url" | tar -xz -C _site || true`. Under `set -eo pipefail`, the `|| true` swallows a **failed or truncated** download/extract — which can leave a **partial** `_site` tree where `count > 0`, so lychee runs against an incomplete site and re-introduces exactly the "file not found" false positives this workflow was fixed to avoid.

## Change

Use `curl -f` (fail on HTTP errors) and an `if !` guard that clears `_site` on any download/extract failure, so a bad fetch is treated as "no usable asset" and surfaced by the existing empty-input guard (which reports "release asset missing") rather than silently checking a half-extracted site.

Single-line-of-logic change to `.github/workflows/linkcheck.yml`; no behavioural change on the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)