### PR TITLE
Add actions: read for the cache artifact download

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: write   # write: upload release assets (html archive, checksum, manifest)
+  actions: read     # dawidd6/action-download-artifact reads the cache.yml build artifact
   pages: write
   id-token: write   # required for OIDC-based Pages deployment
 


### PR DESCRIPTION
Ports the fix from QuantEcon/lecture-jax#331 (a Copilot-review catch) to keep the two repos' publish workflows in sync.

## Why

The migration added an explicit `permissions:` block, which sets every **unlisted** scope to `none`. The publish job's `dawidd6/action-download-artifact` step reads the Jupyter build cache from `cache.yml` via the Actions API, which needs `actions: read`.

The last publish (`publish-2026jul07`) still succeeded with only Contents/Metadata/Pages granted — so this isn't currently breaking — but `actions: read` is the documented requirement for that action and is exactly what issue QuantEcon/meta#282's permissions example lists (`actions: read # needed if other workflows download artifacts`). Adding it guarantees the cache download and removes a latent gap.

## Change

One line added to the `permissions:` block in `.github/workflows/publish.yml`:

    actions: read     # dawidd6/action-download-artifact reads the cache.yml build artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)