### PR TITLE
Move link checking to QuantEcon/action-link-checker

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,4 +1,4 @@
-name: Link Checker [Anaconda, Linux]
+name: Link Checker
 on:
   schedule:
     # UTC 23:00 is early morning in Australia (9am)
@@ -42,7 +42,7 @@ jobs:
             exit 1
           fi
       - name: AI-Powered Link Checker
-        uses: QuantEcon/action-link-checker@main
+        uses: QuantEcon/action-link-checker@v1.0.0
         with:
           html-path: '_site'
           fail-on-broken: 'false'

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,4 +1,4 @@
-name: Link Checker
+name: Link Checker [Anaconda, Linux]
 on:
   schedule:
     # UTC 23:00 is early morning in Australia (9am)
@@ -6,74 +6,46 @@ on:
   workflow_dispatch:
 jobs:
   link-checking:
-    name: Link Checking
+    name: QuantEcon AI link checking
     runs-on: "ubuntu-latest"
     permissions:
-      contents: read  # read the latest release asset
-      issues: write   # required for peter-evans/create-issue-from-file
+      contents: read  # read latest release assets via gh api
+      issues: write   # required for QuantEcon link-checker
     steps:
       # This repo deploys GitHub Pages via the artifact workflow (no gh-pages
-      # branch). Check links against the published HTML release asset — a
-      # permanent tarball of the full site (HTML plus _static/_images/_pdf/
-      # _notebooks) — so lychee resolves local asset and root-relative links
-      # without depending on the live site being reachable.
-      - name: Download and extract latest release HTML
-        id: fetch
+      # branch), so check links against the published HTML release asset — a
+      # permanent tarball of the full site, not subject to artifact expiry.
+      - name: Get latest release asset URL
+        id: release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # `|| true` + 2>/dev/null: a transient gh api error (rate-limit/auth)
-          # must not abort the step under `set -eo pipefail` — fall through to
-          # the empty-input guard below so it reports "release asset missing".
-          asset_url=$(gh api repos/${{ github.repository }}/releases/latest \
-            --jq '.assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url' 2>/dev/null | head -1 || true)
-          mkdir -p _site
-          if [ -n "$asset_url" ]; then
-            # `curl -f` fails on HTTP errors; an `if !` guard catches a failed
-            # or partial download/extract and discards the incomplete tree, so
-            # lychee never runs against a half-extracted site (which would
-            # reintroduce "file not found" false positives).
-            if ! curl -fsSL "$asset_url" | tar -xz -C _site; then
-              echo "::warning::could not download/extract $asset_url — treating as no usable asset"
-              rm -rf _site && mkdir -p _site
-            fi
+          set -euo pipefail
+          ASSET_URL=$(gh api repos/${{ github.repository }}/releases/latest \
+            --jq '[.assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url] | first // ""')
+          if [ -z "$ASSET_URL" ]; then
+            echo "::error::No .tar.gz asset found on the latest release"
+            exit 1
           fi
+          echo "asset-url=$ASSET_URL" >> "$GITHUB_OUTPUT"
+      - name: Download and extract release HTML
+        run: |
+          set -euo pipefail
+          mkdir -p _site
+          curl -fsSL "${{ steps.release.outputs.asset-url }}" | tar -xzf - -C _site
+          # Guard against an empty or partial extract: with no HTML to scan the
+          # checker reports a clean run instead of surfacing the failure.
           count=$(find _site -name '*.html' | wc -l | tr -d ' ')
           echo "Extracted $count HTML file(s) from the latest release asset"
           if [ "$count" -eq 0 ]; then
-            # No usable release asset — don't run lychee against an empty tree
-            # and report green; surface the failure instead.
-            echo "ok=false" >> "$GITHUB_OUTPUT"
-            mkdir -p lychee
-            {
-              echo "## Link Checker — release asset missing"
-              echo
-              echo "Could not download or extract an HTML \`.tar.gz\` from the latest release, so the link check did not run."
-              echo "Check that the most recent \`publish-*\` release has the \`continuous-time-mcs-html-*.tar.gz\` asset attached."
-            } > lychee/out.md
-          else
-            echo "ok=true" >> "$GITHUB_OUTPUT"
+            echo "::error::No HTML files extracted from the release asset"
+            exit 1
           fi
-
-      - name: Link Checker
-        id: lychee
-        if: steps.fetch.outputs.ok == 'true'
-        uses: lycheeverse/lychee-action@v2
+      - name: AI-Powered Link Checker
+        uses: QuantEcon/action-link-checker@main
         with:
-          fail: false
-          # Check only the top-level lecture pages (as the old checkout did) —
-          # not theme partials under _static/ (e.g. webpack-macros.html holds
-          # raw Jinja `{{ pathto(...) }}` that isn't a real link).
-          # 200 must stay in --accept or every working link is flagged as an
-          # error. --root-dir resolves root-relative links (e.g.
-          # /_notebooks/*.ipynb, /_pdf/book.pdf) against the extracted site root.
-          args: --accept 200,403,503 --root-dir ${{ github.workspace }}/_site '_site/*.html'
-
-      # Open an issue if the release asset was missing, or lychee found broken links.
-      - name: Create Issue From File
-        if: steps.fetch.outputs.ok != 'true' || steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v6
-        with:
-          title: Link Checker Report
-          content-filepath: ./lychee/out.md
-          labels: report, automated issue, linkchecker
+          html-path: '_site'
+          fail-on-broken: 'false'
+          silent-codes: '403,503'
+          ai-suggestions: 'true'
+          create-issue: 'true'


### PR DESCRIPTION
Replaces the lychee-based link check with the shared **`QuantEcon/action-link-checker`**, bringing this repo in line with `lecture-python-intro`, `lecture-python-advanced.myst` and `lecture-python-programming.myst`.

This supersedes #178, which patched the old lychee invocation with `--exclude-path` flags. That PR was opened against an earlier version of `linkcheck.yml` and no longer merges cleanly; more importantly, the class of false positive it worked around cannot occur under the new checker at all.

## Why this fixes #173

The link checker reported errors in `genindex.html` and `prf-prf.html` because `quantecon-book-theme` renders a "Download Notebook" toolbar button on every HTML page, including auto-generated Sphinx utility pages that have no source notebook. On those pages the button emits a literal `href="None"`, which lychee then tried to resolve as a local file.

The QuantEcon action extracts only external `http(s)` links from `<a href>` tags, so `href="None"` is never a candidate — no exclusion list needed, and the same problem cannot reappear on future auto-generated pages.

## Verification

I downloaded the current published release tarball (`publish-2026jul14`) and ran the action's `link_checker.py` against it locally:

| Check | Result |
|---|---|
| `href="None"` present in `genindex.html` / `prf-prf.html` | 1 occurrence each — confirms the root cause of #173 |
| External links extracted from those two pages | 8 each, none of them the `None` href |
| Full network run on `genindex.html` | **0 broken, 0 redirects** |
| `_static/webpack-macros.html` (theme partial, raw Jinja) | 0 links — contributes no noise |
| Total external links across the site | 250 |

The tarball extracts flat into `_site`, so `html-path: '_site'` picks up all 15 lecture pages. Because the action scans recursively but ignores non-external hrefs, the old `_site/*.html` glob restriction that kept lychee away from theme partials is no longer needed.

## What is kept, and what changes

The release-asset download is unchanged in spirit: this repo publishes Pages via the artifact workflow (there is no `gh-pages` branch), so the HTML still comes from the latest `publish-*` release tarball. I kept the extracted-file-count guard so an empty or partial extract fails loudly rather than reporting a clean run against an empty tree.

One trade-off worth stating plainly: lychee checked ~850 targets including local files, images and anchors, whereas this action checks the 250 external links only. Broken *internal* links will no longer be caught by the scheduled run. That is the same trade-off already accepted in the three sibling lecture repos, and it is what removes the recurring false-positive reports — but it is a real reduction in coverage, so flagging it rather than burying it.

Issue creation is retained via `create-issue: 'true'`, with AI-powered suggestions enabled and `403,503` treated as silent codes.

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
