### PR TITLE
Pin the link checker to v1

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -42,7 +42,7 @@ jobs:
             exit 1
           fi
       - name: AI-Powered Link Checker
-        uses: QuantEcon/action-link-checker@v1.0.0
+        uses: QuantEcon/action-link-checker@v1
         with:
           html-path: '_site'
           fail-on-broken: 'false'


### PR DESCRIPTION
`linkcheck.yml` pinned the link checker at `@v1.0.0`, which resolves to `890d35e` — the action repository's very first commit, from before its test suite, CI workflow and README fixes existed. Nothing errored, because that early `action.yml` happens to accept all five inputs this workflow passes, so the workflow has been silently running pre-release code.

Repinned to `@v1`, the moving tag created with the [v1.1.0 release](https://github.com/QuantEcon/action-link-checker/releases/tag/v1.1.0).

That release matters here because this workflow sets `create-issue: 'true'` on a weekly cron. Before v1.1.0 every run opened a fresh issue; now a recurring finding refreshes one open issue instead. It also fixes a bug where a timeout on a well-known host was always reported broken — the allowance meant to absorb that could never fire on a timeout, only on a connection error.

No findings are outstanding in this repository right now, so this is preventative. `lectures/_config.yml` has an empty `linkcheck_ignore`, so there is nothing to mirror into `ignore-patterns` yet.
